### PR TITLE
feat(review): integrate voice pronunciation in review flashcards

### DIFF
--- a/apps/user/src/features/review/components/flashcard.tsx
+++ b/apps/user/src/features/review/components/flashcard.tsx
@@ -6,12 +6,14 @@ import {
   CardHeader,
   Divider,
   Heading,
+  HStack,
   SimpleGrid,
   Text,
   VStack,
   Wrap,
   WrapItem,
 } from '@chakra-ui/react';
+import { PronunciationButton } from '@ielts/ui';
 import type { ReviewWord } from '../types';
 
 interface FlashcardProps {
@@ -102,9 +104,16 @@ export function Flashcard({ word, isFlipped, onFlip }: FlashcardProps) {
         <VStack spacing={8} justify="center" minH="320px" px={4}>
           {!isFlipped ? (
             <VStack spacing={6}>
-              <Heading size="3xl" textAlign="center" color="brand.400">
-                {word.word}
-              </Heading>
+              <HStack spacing={3} justify="center">
+                <Heading size="3xl" textAlign="center" color="brand.400">
+                  {word.word}
+                </Heading>
+                <PronunciationButton
+                  word={word.word}
+                  size="md"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </HStack>
               <VStack spacing={2}>
                 <Text color="gray.500" fontSize="md">
                   Click anywhere or press
@@ -128,9 +137,16 @@ export function Flashcard({ word, isFlipped, onFlip }: FlashcardProps) {
             </VStack>
           ) : (
             <VStack spacing={6} w="full" align="stretch">
-              <Heading size="2xl" color="brand.400" textAlign="center">
-                {word.word}
-              </Heading>
+              <HStack spacing={3} justify="center">
+                <Heading size="2xl" color="brand.400" textAlign="center">
+                  {word.word}
+                </Heading>
+                <PronunciationButton
+                  word={word.word}
+                  size="sm"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              </HStack>
               <Divider borderColor="gray.700" />
               <Box>
                 <Text

--- a/apps/user/src/features/review/components/flashcard.tsx
+++ b/apps/user/src/features/review/components/flashcard.tsx
@@ -15,6 +15,7 @@ import {
 } from '@chakra-ui/react';
 import { PronunciationButton } from '@ielts/ui';
 import type { ReviewWord } from '../types';
+import type { MouseEvent } from 'react';
 
 interface FlashcardProps {
   word: ReviewWord;
@@ -35,7 +36,11 @@ const getDifficultyColor = (difficulty: string) => {
   }
 };
 
+
 export function Flashcard({ word, isFlipped, onFlip }: FlashcardProps) {
+  const handlePronunciationClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+  };
   return (
     <Card
       bg="gray.800"
@@ -111,7 +116,7 @@ export function Flashcard({ word, isFlipped, onFlip }: FlashcardProps) {
                 <PronunciationButton
                   word={word.word}
                   size="md"
-                  onClick={(e) => e.stopPropagation()}
+                  onClick={handlePronunciationClick}
                 />
               </HStack>
               <VStack spacing={2}>
@@ -144,7 +149,7 @@ export function Flashcard({ word, isFlipped, onFlip }: FlashcardProps) {
                 <PronunciationButton
                   word={word.word}
                   size="sm"
-                  onClick={(e) => e.stopPropagation()}
+                  onClick={handlePronunciationClick}
                 />
               </HStack>
               <Divider borderColor="gray.700" />

--- a/libs/ui/src/components/pronunciation-button.tsx
+++ b/libs/ui/src/components/pronunciation-button.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+  IconButton,
+  Spinner,
+  Tooltip,
+} from '@chakra-ui/react';
+import { Volume2 } from 'lucide-react';
+import type { MouseEvent } from 'react';
+import { useSpeechSynthesis } from '../hooks/use-speech-synthesis';
+
+interface PronunciationButtonProps {
+  word: string;
+  size?: 'sm' | 'md';
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+export function PronunciationButton({
+  word,
+  size = 'sm',
+  onClick,
+}: PronunciationButtonProps) {
+  const { speak, isSpeaking, isLoading, isSupported } = useSpeechSynthesis({
+    text: word,
+    lang: 'en',
+    voiceLang: 'en-GB',
+  });
+
+  if (!isSupported) {
+    return null;
+  }
+
+  const tooltipLabel = isLoading
+    ? 'Loading voice...'
+    : isSpeaking
+    ? 'Playing...'
+    : 'Listen to pronunciation';
+
+  const iconSize = size === 'md' ? 22 : 20;
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    speak();
+  };
+
+  return (
+    <Tooltip label={tooltipLabel} placement="top">
+      <IconButton
+        aria-label="Pronounce word"
+        icon={
+          isLoading ? (
+            <Spinner size="sm" />
+          ) : (
+            <Volume2 size={iconSize} />
+          )
+        }
+        size={size}
+        colorScheme="brand"
+        variant={isSpeaking ? 'solid' : 'ghost'}
+        onClick={handleClick}
+        isDisabled={isLoading}
+        _hover={{ bg: 'brand.600' }}
+        alignSelf="center"
+      />
+    </Tooltip>
+  );
+}

--- a/libs/ui/src/components/pronunciation-button.tsx
+++ b/libs/ui/src/components/pronunciation-button.tsx
@@ -40,6 +40,7 @@ export function PronunciationButton({
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     onClick?.(e);
+    if (e.defaultPrevented) return;
     speak();
   };
 

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -8,6 +8,7 @@ export { ReactQueryProvider } from './providers/react-query-provider';
 export * from './components/ui/button';
 export * from './components/ui/card';
 export * from './components/ui/input';
+export { PronunciationButton } from './components/pronunciation-button';
 export { useSpeechSynthesis } from './hooks/use-speech-synthesis';
 export { LoadingSpinner } from './lib/loading-spinner';
 export { PageLoadingFallback } from './lib/page-loading-fallback';

--- a/libs/ui/src/lib/WordDetailsModal.tsx
+++ b/libs/ui/src/lib/WordDetailsModal.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   Heading,
   HStack,
-  IconButton,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -14,16 +13,13 @@ import {
   ModalHeader,
   ModalOverlay,
   SimpleGrid,
-  Spinner,
   Text,
-  Tooltip,
   VStack,
   Wrap,
   WrapItem,
 } from '@chakra-ui/react';
-import { Volume2 } from 'lucide-react';
 import { Button } from '@ielts/ui';
-import { useSpeechSynthesis } from '../hooks/use-speech-synthesis';
+import { PronunciationButton } from '../components/pronunciation-button';
 
 interface WordDetailsModalProps {
   isOpen: boolean;
@@ -46,12 +42,7 @@ export function WordDetailsModal({
   onClose,
   word,
 }: WordDetailsModalProps) {
-  // Preload pronunciation when modal opens - must be called before any returns
-  const { speak, isSpeaking, isLoading, isSupported } = useSpeechSynthesis({
-    text: word?.word || '',
-    lang: 'en',
-    voiceLang: 'en-GB', // UK English
-  });
+
 
   if (!word) return null;
 
@@ -84,37 +75,7 @@ export function WordDetailsModal({
                 <Heading size="2xl" color="brand.400" lineHeight="shorter">
                   {word.word}
                 </Heading>
-                {/* Pronunciation Button */}
-                {isSupported && (
-                  <Tooltip
-                    label={
-                      isLoading
-                        ? 'Loading voice...'
-                        : isSpeaking
-                        ? 'Playing...'
-                        : 'Listen to pronunciation'
-                    }
-                    placement="top"
-                  >
-                    <IconButton
-                      aria-label="Pronounce word"
-                      icon={
-                        isLoading ? (
-                          <Spinner size="sm" />
-                        ) : (
-                          <Volume2 size={20} />
-                        )
-                      }
-                      size="sm"
-                      colorScheme="brand"
-                      variant={isSpeaking ? 'solid' : 'ghost'}
-                      onClick={speak}
-                      isDisabled={isLoading}
-                      _hover={{ bg: 'brand.600' }}
-                      alignSelf="center"
-                    />
-                  </Tooltip>
-                )}
+                <PronunciationButton word={word.word} size="sm" />
                 {word.partOfSpeech && (
                   <Badge
                     colorScheme="blue"


### PR DESCRIPTION
## Description
Closes #58

This PR brings the text-to-speech pronunciation feature to the Review Session flashcards, allowing users to listen to English pronunciation while reviewing words. 

To achieve this cleanly and adhere to DRY principles, the inline pronunciation button logic from the `WordDetailsModal` was extracted into a shared, reusable `<PronunciationButton />` UI component and then integrated into both locations.

## Changes Made
- **UI Library (`@ielts/ui`)**:
  - Created a new `<PronunciationButton />` component in `libs/ui/src/components/pronunciation-button.tsx`.
  - Refactored `WordDetailsModal.tsx` to use the new shared component, reducing code duplication.
- **User App (`apps/user`)**:
  - Integrated `<PronunciationButton />` into the `Flashcard` component (`apps/user/src/features/review/components/flashcard.tsx`).
  - Added the button to both the **front (question)** and **back (answer)** views of the flashcard.
  - Implemented `e.stopPropagation()` on the button click to prevent the overarching card flip action when listening to the pronunciation.

## Acceptance Criteria Met
- [x] Speaker icon appears next to the word on the Review Flashcard.
- [x] Clicking the icon plays the pronunciation of the English word (defaults to UK English `en-GB`).
- [x] Clicking the icon does not flip the card.
- [x] Feature works on both the front and back of the card.
- [x] Loading state (spinner) is shown while the voice is initializing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pronunciation control to hear word audio from flashcards and word details.
  * Consistent playback UI with loading and playing states.
* **Bug Fixes**
  * Pronunciation clicks no longer flip flashcards unintentionally.
* **Other**
  * Button sizing adapts between card front/back and modal for consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->