### PR TITLE
feat: add personal vocabulary lists

### DIFF
--- a/apps/backend/src/api.routes.ts
+++ b/apps/backend/src/api.routes.ts
@@ -7,6 +7,7 @@ import srsRoutes from './modules/srs/srs.routes';
 import topicsRoutes from './modules/topics/topics.routes';
 import userProfileRoutes from './modules/users/users-profile.routes';
 import wordsRoutes from './modules/words/words.routes';
+import wordListRoutes from './modules/word-list/word-list.routes';
 
 const router = Router();
 
@@ -18,5 +19,6 @@ router.use('/topics', topicsRoutes);
 router.use('/quiz', quizRoutes);
 router.use('/admin', adminRoutes);
 router.use('/srs', srsRoutes);
+router.use('/word-lists', wordListRoutes);
 
 export default router;

--- a/apps/backend/src/modules/word-list/word-list.controller.ts
+++ b/apps/backend/src/modules/word-list/word-list.controller.ts
@@ -1,0 +1,78 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { AuthRequest } from '../auth/auth.middleware';
+import { WordListService } from './word-list.service';
+
+export class WordListController {
+  static async getAll(req: Request, res: Response, next: NextFunction) {
+    try {
+      const authReq = req as AuthRequest;
+      const userId = authReq.user?.id;
+      const lists = await WordListService.getUserLists(userId);
+      res.json({ success: true, data: lists });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  static async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const authReq = req as AuthRequest;
+      const userId = authReq.user?.id;
+      const { name } = req.body;
+      const list = await WordListService.createList(userId, name);
+      res.status(201).json({ success: true, data: list });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  static async rename(req: Request, res: Response, next: NextFunction) {
+    try {
+      const authReq = req as AuthRequest;
+      const userId = authReq.user?.id;
+      const { listId } = req.params;
+      const { name } = req.body;
+      const list = await WordListService.renameList(userId, listId, name);
+      res.json({ success: true, data: list });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  static async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const authReq = req as AuthRequest;
+      const userId = authReq.user?.id;
+      const { listId } = req.params;
+      await WordListService.deleteList(userId, listId);
+      res.json({ success: true, message: 'List deleted' });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  static async addWord(req: Request, res: Response, next: NextFunction) {
+    try {
+      const authReq = req as AuthRequest;
+      const userId = authReq.user?.id;
+      const { listId } = req.params;
+      const { wordId } = req.body;
+      const list = await WordListService.addWord(userId, listId, wordId);
+      res.json({ success: true, data: list });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  static async removeWord(req: Request, res: Response, next: NextFunction) {
+    try {
+      const authReq = req as AuthRequest;
+      const userId = authReq.user?.id;
+      const { listId, wordId } = req.params;
+      const list = await WordListService.removeWord(userId, listId, wordId);
+      res.json({ success: true, data: list });
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/apps/backend/src/modules/word-list/word-list.model.ts
+++ b/apps/backend/src/modules/word-list/word-list.model.ts
@@ -1,0 +1,38 @@
+import mongoose, { type Document, Schema } from 'mongoose';
+
+export interface IWordList extends Document {
+  user: mongoose.Types.ObjectId;
+  name: string;
+  words: mongoose.Types.ObjectId[];
+}
+
+const WordListSchema = new Schema<IWordList>(
+  {
+    user: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 100,
+    },
+    words: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: 'Word',
+      },
+    ],
+  },
+  { timestamps: true, versionKey: false },
+);
+
+// Prevent duplicate list names per user
+WordListSchema.index({ user: 1, name: 1 }, { unique: true });
+
+export const WordList =
+  mongoose.models['WordList'] ||
+  mongoose.model<IWordList>('WordList', WordListSchema);

--- a/apps/backend/src/modules/word-list/word-list.routes.ts
+++ b/apps/backend/src/modules/word-list/word-list.routes.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 import {
   createRateLimiter,
-  moderateRateLimit,
 } from '../../core/middleware/rate-limit.middleware';
 import { authenticate } from '../auth/auth.middleware';
 import { WordListController } from './word-list.controller';
@@ -11,8 +10,14 @@ const router = Router();
 // All routes require authentication
 router.use(authenticate);
 
-// Read endpoints
-router.get('/', moderateRateLimit, WordListController.getAll);
+// Read endpoints with user-aware rate limiting (30 reads per min)
+const readRateLimit = createRateLimiter(
+  60 * 1000,
+  30,
+  'Too many requests, please try again shortly',
+);
+
+router.get('/', readRateLimit, WordListController.getAll);
 
 // Write endpoints with rate limiting (60 writes per 10 min)
 const writeRateLimit = createRateLimiter(

--- a/apps/backend/src/modules/word-list/word-list.routes.ts
+++ b/apps/backend/src/modules/word-list/word-list.routes.ts
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import {
+  createRateLimiter,
+  moderateRateLimit,
+} from '../../core/middleware/rate-limit.middleware';
+import { authenticate } from '../auth/auth.middleware';
+import { WordListController } from './word-list.controller';
+
+const router = Router();
+
+// All routes require authentication
+router.use(authenticate);
+
+// Read endpoints
+router.get('/', moderateRateLimit, WordListController.getAll);
+
+// Write endpoints with rate limiting (60 writes per 10 min)
+const writeRateLimit = createRateLimiter(
+  10 * 60 * 1000,
+  60,
+  'Too many list operations',
+);
+
+router.post('/', writeRateLimit, WordListController.create);
+router.patch('/:listId', writeRateLimit, WordListController.rename);
+router.delete('/:listId', writeRateLimit, WordListController.delete);
+router.post('/:listId/words', writeRateLimit, WordListController.addWord);
+router.delete(
+  '/:listId/words/:wordId',
+  writeRateLimit,
+  WordListController.removeWord,
+);
+
+export default router;

--- a/apps/backend/src/modules/word-list/word-list.service.ts
+++ b/apps/backend/src/modules/word-list/word-list.service.ts
@@ -32,17 +32,28 @@ export class WordListService {
   }
 
   static async renameList(userId: string, listId: string, name: string) {
-    const list = await WordList.findOneAndUpdate(
-      { _id: listId, user: userId },
-      { name },
-      { new: true },
-    );
+    try {
+      const list = await WordList.findOneAndUpdate(
+        { _id: listId, user: userId },
+        { name },
+        { new: true, runValidators: true, context: 'query' },
+      );
 
-    if (!list) {
-      throw new AppError('List not found', 404);
+      if (!list) {
+        throw new AppError('List not found', 404);
+      }
+
+      return list;
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as { code?: number }).code === 11000
+      ) {
+        throw new AppError(`A list named "${name}" already exists`, 409);
+      }
+      throw error;
     }
-
-    return list;
   }
 
   static async deleteList(userId: string, listId: string) {
@@ -59,23 +70,45 @@ export class WordListService {
   }
 
   static async addWord(userId: string, listId: string, wordId: string) {
-    // Remove from any other list first (one word = one list)
-    await WordList.updateMany(
-      { user: userId, _id: { $ne: listId }, words: wordId },
-      { $pull: { words: wordId } },
-    );
+    const session = await WordList.startSession();
 
-    const list = await WordList.findOneAndUpdate(
-      { _id: listId, user: userId },
-      { $addToSet: { words: wordId } },
-      { new: true },
-    ).populate(WORDS_POPULATE);
+    try {
+      let updatedList: Awaited<ReturnType<typeof WordList.findOneAndUpdate>> | null = null;
 
-    if (!list) {
-      throw new AppError('List not found', 404);
+      await session.withTransaction(async () => {
+        // Verify target list exists before modifying anything
+        const targetExists = await WordList.findOne({
+          _id: listId,
+          user: userId,
+        }).session(session);
+
+        if (!targetExists) {
+          throw new AppError('List not found', 404);
+        }
+
+        // Remove from any other list (one word = one list)
+        await WordList.updateMany(
+          { user: userId, _id: { $ne: listId }, words: wordId },
+          { $pull: { words: wordId } },
+          { session },
+        );
+
+        // Add to target list
+        updatedList = await WordList.findOneAndUpdate(
+          { _id: listId, user: userId },
+          { $addToSet: { words: wordId } },
+          { new: true, session },
+        ).populate(WORDS_POPULATE);
+      });
+
+      if (!updatedList) {
+        throw new AppError('List not found', 404);
+      }
+
+      return updatedList;
+    } finally {
+      await session.endSession();
     }
-
-    return list;
   }
 
   static async removeWord(userId: string, listId: string, wordId: string) {

--- a/apps/backend/src/modules/word-list/word-list.service.ts
+++ b/apps/backend/src/modules/word-list/word-list.service.ts
@@ -10,7 +10,7 @@ export class WordListService {
   static async getUserLists(userId: string) {
     return WordList.find({ user: userId })
       .populate(WORDS_POPULATE)
-      .sort({ updatedAt: -1 });
+      .sort({ createdAt: 1 });
   }
 
   static async createList(userId: string, name: string) {

--- a/apps/backend/src/modules/word-list/word-list.service.ts
+++ b/apps/backend/src/modules/word-list/word-list.service.ts
@@ -1,0 +1,94 @@
+import { AppError } from '../../core/errors/AppError';
+import { WordList } from './word-list.model';
+
+const WORDS_POPULATE = {
+  path: 'words',
+  populate: { path: 'topics', select: 'name' },
+};
+
+export class WordListService {
+  static async getUserLists(userId: string) {
+    return WordList.find({ user: userId })
+      .populate(WORDS_POPULATE)
+      .sort({ updatedAt: -1 });
+  }
+
+  static async createList(userId: string, name: string) {
+    try {
+      return await WordList.create({ user: userId, name, words: [] });
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as { code: number }).code === 11000
+      ) {
+        throw new AppError(
+          `A list named "${name}" already exists`,
+          409,
+        );
+      }
+      throw error;
+    }
+  }
+
+  static async renameList(userId: string, listId: string, name: string) {
+    const list = await WordList.findOneAndUpdate(
+      { _id: listId, user: userId },
+      { name },
+      { new: true },
+    );
+
+    if (!list) {
+      throw new AppError('List not found', 404);
+    }
+
+    return list;
+  }
+
+  static async deleteList(userId: string, listId: string) {
+    const list = await WordList.findOneAndDelete({
+      _id: listId,
+      user: userId,
+    });
+
+    if (!list) {
+      throw new AppError('List not found', 404);
+    }
+
+    return list;
+  }
+
+  static async addWord(userId: string, listId: string, wordId: string) {
+    // Remove from any other list first (one word = one list)
+    await WordList.updateMany(
+      { user: userId, _id: { $ne: listId }, words: wordId },
+      { $pull: { words: wordId } },
+    );
+
+    const list = await WordList.findOneAndUpdate(
+      { _id: listId, user: userId },
+      { $addToSet: { words: wordId } },
+      { new: true },
+    ).populate(WORDS_POPULATE);
+
+    if (!list) {
+      throw new AppError('List not found', 404);
+    }
+
+    return list;
+  }
+
+  static async removeWord(userId: string, listId: string, wordId: string) {
+    const list = await WordList.findOneAndUpdate(
+      { _id: listId, user: userId },
+      { $pull: { words: wordId } },
+      { new: true },
+    ).populate(WORDS_POPULATE);
+
+    if (!list) {
+      throw new AppError('List not found', 404);
+    }
+
+    return list;
+  }
+}

--- a/apps/user/src/app/my-lists/page.tsx
+++ b/apps/user/src/app/my-lists/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import { WordListContainer } from '../../features/word-list';
+
+export const metadata: Metadata = {
+  title: 'My Lists',
+  description: 'Manage your personal vocabulary lists. (Private Page)',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function MyListsPage() {
+  return <WordListContainer />;
+}

--- a/apps/user/src/components/navbar/desktop-nav.tsx
+++ b/apps/user/src/components/navbar/desktop-nav.tsx
@@ -17,6 +17,7 @@ export const DesktopNav = ({ isAuthenticated, dueCount }: DesktopNavProps) => {
       {isAuthenticated && (
         <>
           <NavLink href="/dashboard">Dashboard</NavLink>
+          <NavLink href="/my-lists">My Lists</NavLink>
           <NavLink href="/review">
             Review
             {dueCount > 0 && (

--- a/apps/user/src/components/navbar/mobile-nav.tsx
+++ b/apps/user/src/components/navbar/mobile-nav.tsx
@@ -23,6 +23,7 @@ import {
   HelpCircle,
   Home,
   LayoutDashboard,
+  List,
   LogIn,
   LogOut,
   RotateCcw,
@@ -114,6 +115,9 @@ export const MobileNav = ({
                   onClick={onClose}
                 >
                   Dashboard
+                </MobileNavLink>
+                <MobileNavLink href="/my-lists" icon={<List size={20} />} onClick={onClose}>
+                  My Lists
                 </MobileNavLink>
                 <MobileNavLink href="/profile" icon={<User size={20} />} onClick={onClose}>
                   Profile Settings

--- a/apps/user/src/features/dashboard/components/action-card.tsx
+++ b/apps/user/src/features/dashboard/components/action-card.tsx
@@ -1,15 +1,16 @@
-import { Heading, Text } from '@chakra-ui/react';
+import { Box, Heading, Text } from '@chakra-ui/react';
 import { Card, CardContent, CardHeader } from '@ielts/ui';
+import type { LucideIcon } from 'lucide-react';
 import Link from 'next/link';
 
 interface ActionCardProps {
   href: string;
   title: string;
   description: string;
-  emoji: string;
+  icon: LucideIcon;
 }
 
-export function ActionCard({ href, title, description, emoji }: ActionCardProps) {
+export function ActionCard({ href, title, description, icon: Icon }: ActionCardProps) {
   return (
     <Link href={href} style={{ textDecoration: 'none' }} aria-label={`${title}: ${description}`}>
       <Card
@@ -19,9 +20,16 @@ export function ActionCard({ href, title, description, emoji }: ActionCardProps)
         tabIndex={0}
       >
         <CardHeader>
-          <Text fontSize="3xl" mb={2} aria-hidden="true">
-            {emoji}
-          </Text>
+          <Box
+            display="inline-flex"
+            p={3}
+            mb={2}
+            borderRadius="xl"
+            bg="whiteAlpha.100"
+            color="brand.400"
+          >
+            <Icon size={28} strokeWidth={1.5} />
+          </Box>
           <Heading size="md" color="brand.400">
             {title}
           </Heading>

--- a/apps/user/src/features/dashboard/components/action-card.tsx
+++ b/apps/user/src/features/dashboard/components/action-card.tsx
@@ -28,7 +28,7 @@ export function ActionCard({ href, title, description, icon: Icon }: ActionCardP
             bg="whiteAlpha.100"
             color="brand.400"
           >
-            <Icon size={28} strokeWidth={1.5} />
+            <Icon size={28} strokeWidth={1.5} aria-hidden="true" focusable={false} />
           </Box>
           <Heading size="md" color="brand.400">
             {title}

--- a/apps/user/src/features/dashboard/components/quick-actions.tsx
+++ b/apps/user/src/features/dashboard/components/quick-actions.tsx
@@ -1,4 +1,5 @@
 import { SimpleGrid } from '@chakra-ui/react';
+import { BookOpen, BrainCircuit, BarChart3 } from 'lucide-react';
 import { ActionCard } from './action-card';
 
 export function QuickActions() {
@@ -8,19 +9,19 @@ export function QuickActions() {
         href="/vocabulary"
         title="Browse Vocabulary"
         description="Explore 3500+ IELTS words"
-        emoji="📚"
+        icon={BookOpen}
       />
       <ActionCard
         href="/quiz"
         title="Take a Quiz"
         description="Test your knowledge now"
-        emoji="🎯"
+        icon={BrainCircuit}
       />
       <ActionCard
         href="/analytics"
         title="View Analytics"
         description="Check your progress"
-        emoji="📊"
+        icon={BarChart3}
       />
     </SimpleGrid>
   );

--- a/apps/user/src/features/landing/components/features-section.tsx
+++ b/apps/user/src/features/landing/components/features-section.tsx
@@ -1,34 +1,45 @@
 import { Box, Heading, SimpleGrid, Text } from '@chakra-ui/react';
-
-export function FeaturesSection() {
-  return (
-    <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8} py={8}>
-      <FeatureCard
-        icon="📚"
-        title="3500+ Words"
-        description="Comprehensive IELTS vocabulary database with meanings, examples, and usage"
-      />
-      <FeatureCard
-        icon="🎯"
-        title="Adaptive Quizzes"
-        description="Smart quizzes that adapt to your level and track your progress"
-      />
-      <FeatureCard
-        icon="📊"
-        title="Analytics"
-        description="Detailed performance tracking and insights to improve faster"
-      />
-    </SimpleGrid>
-  );
-}
+import { BookOpen, BrainCircuit, BarChart3 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface FeatureCardProps {
-  icon: string;
+  icon: LucideIcon;
   title: string;
   description: string;
 }
 
-function FeatureCard({ icon, title, description }: FeatureCardProps) {
+const FEATURES: FeatureCardProps[] = [
+  {
+    icon: BookOpen,
+    title: '3500+ Words',
+    description:
+      'Comprehensive IELTS vocabulary database with meanings, examples, and usage',
+  },
+  {
+    icon: BrainCircuit,
+    title: 'Adaptive Quizzes',
+    description:
+      'Smart quizzes that adapt to your level and track your progress',
+  },
+  {
+    icon: BarChart3,
+    title: 'Analytics',
+    description:
+      'Detailed performance tracking and insights to improve faster',
+  },
+];
+
+export function FeaturesSection() {
+  return (
+    <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8} py={8}>
+      {FEATURES.map((feature) => (
+        <FeatureCard key={feature.title} {...feature} />
+      ))}
+    </SimpleGrid>
+  );
+}
+
+function FeatureCard({ icon: Icon, title, description }: FeatureCardProps) {
   return (
     <Box
       bg="gray.800"
@@ -46,9 +57,16 @@ function FeatureCard({ icon, title, description }: FeatureCardProps) {
         boxShadow: '0 10px 30px rgba(30, 136, 229, 0.3)',
       }}
     >
-      <Text fontSize="4xl" mb={4}>
-        {icon}
-      </Text>
+      <Box
+        display="inline-flex"
+        p={3}
+        mb={4}
+        borderRadius="xl"
+        bg="whiteAlpha.100"
+        color="brand.400"
+      >
+        <Icon size={28} strokeWidth={1.5} />
+      </Box>
       <Heading size="md" color="white" mb={3}>
         {title}
       </Heading>

--- a/apps/user/src/features/landing/components/features-section.tsx
+++ b/apps/user/src/features/landing/components/features-section.tsx
@@ -65,7 +65,7 @@ function FeatureCard({ icon: Icon, title, description }: FeatureCardProps) {
         bg="whiteAlpha.100"
         color="brand.400"
       >
-        <Icon size={28} strokeWidth={1.5} />
+        <Icon size={28} strokeWidth={1.5} aria-hidden="true" focusable={false} />
       </Box>
       <Heading size="md" color="white" mb={3}>
         {title}

--- a/apps/user/src/features/vocabulary/index.tsx
+++ b/apps/user/src/features/vocabulary/index.tsx
@@ -17,6 +17,7 @@ import { VocabularyFilters } from './components/vocabulary-filters';
 import { VocabularyList } from './components/vocabulary-list';
 import { useVocabulary } from './hooks/use-vocabulary';
 import type { Word } from './types';
+import { SaveToListButton } from '../word-list/components/save-to-list-button';
 
 const DIFFICULTY_OPTIONS = [
   'all',
@@ -137,6 +138,12 @@ export function VocabularyContainer() {
           isOpen={isOpen}
           onClose={onClose}
           word={selectedWord}
+          headerAction={
+            <SaveToListButton
+              wordId={selectedWord?._id ?? ''}
+              isAuthenticated={!!user}
+            />
+          }
         />
       </Container>
     </Box>

--- a/apps/user/src/features/word-list/components/list-card.tsx
+++ b/apps/user/src/features/word-list/components/list-card.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import {
-  Badge,
   Box,
+  Collapse,
   Heading,
   HStack,
   IconButton,
@@ -11,12 +11,13 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
-  SimpleGrid,
   Text,
+  useDisclosure,
   useToast,
-  VStack,
+  Wrap,
+  WrapItem,
 } from '@chakra-ui/react';
-import { MoreVertical, Pencil, Trash2, X } from 'lucide-react';
+import { BookOpen, ChevronDown, ChevronRight, MoreHorizontal, Pencil, Trash2, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 import type { Word } from '../../vocabulary/types';
 import type { WordList } from '../types';
@@ -27,10 +28,10 @@ interface ListCardProps {
   onViewDetails: (word: Word) => void;
 }
 
-const DIFFICULTY_COLORS: Record<string, string> = {
-  beginner: 'green',
-  intermediate: 'blue',
-  advanced: 'purple',
+const DIFFICULTY_DOT_COLORS: Record<string, string> = {
+  beginner: 'green.400',
+  intermediate: 'blue.400',
+  advanced: 'purple.400',
 };
 
 export function ListCard({ list, onViewDetails }: ListCardProps) {
@@ -38,6 +39,7 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
   const deleteList = useDeleteList();
   const removeWord = useRemoveWord();
   const toast = useToast();
+  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: true });
 
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(list.name);
@@ -107,7 +109,8 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
     }
   };
 
-  const handleRemoveWord = async (wordId: string) => {
+  const handleRemoveWord = async (wordId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
     try {
       await removeWord.mutateAsync({ listId: list._id, wordId });
     } catch {
@@ -121,66 +124,90 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
   };
 
   return (
-    <Box
-      bg="gray.800"
-      borderWidth="1px"
-      borderColor="gray.700"
-      borderRadius="lg"
-      p={5}
-    >
-      {/* List Header */}
-      <HStack justify="space-between" mb={4}>
-        {isEditing ? (
-          <HStack flex={1}>
+    <Box>
+      {/* Section Header */}
+      <HStack
+        justify="space-between"
+        py={2.5}
+        px={1}
+        cursor="pointer"
+        _hover={{ bg: 'whiteAlpha.50' }}
+        borderRadius="lg"
+        transition="background 0.15s"
+        onClick={onToggle}
+      >
+        <HStack spacing={3} flex={1} minW={0}>
+          <Box color="gray.500" transition="transform 0.2s">
+            {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+          </Box>
+
+          {isEditing ? (
             <Input
               ref={inputRef}
               value={editName}
               onChange={(e) => setEditName(e.target.value)}
               onKeyDown={handleKeyDown}
               onBlur={handleSaveRename}
+              onClick={(e) => e.stopPropagation()}
               size="sm"
-              bg="gray.900"
+              bg="gray.800"
               borderColor="gray.600"
-              _focus={{ borderColor: 'brand.400' }}
-              maxW="300px"
+              borderRadius="lg"
+              _focus={{ borderColor: 'brand.400', boxShadow: '0 0 0 1px var(--chakra-colors-brand-400)' }}
+              maxW="240px"
             />
-          </HStack>
-        ) : (
-          <HStack spacing={3}>
-            <Heading size="md" color="white">
-              {list.name}
-            </Heading>
-            <Badge colorScheme="brand" variant="subtle" fontSize="xs">
-              {list.words.length} {list.words.length === 1 ? 'word' : 'words'}
-            </Badge>
-          </HStack>
-        )}
+          ) : (
+            <HStack spacing={2}>
+              <Heading size="sm" color="gray.200" fontWeight="600" noOfLines={1}>
+                {list.name}
+              </Heading>
+              <Text fontSize="xs" color="gray.600">
+                {list.words.length}
+              </Text>
+            </HStack>
+          )}
+        </HStack>
 
         <Menu>
           <MenuButton
             as={IconButton}
-            icon={<MoreVertical size={16} />}
+            icon={<MoreHorizontal size={15} />}
             variant="ghost"
-            size="sm"
-            color="gray.400"
-            _hover={{ color: 'white', bg: 'gray.700' }}
+            size="xs"
+            color="gray.600"
+            _hover={{ color: 'gray.300', bg: 'whiteAlpha.100' }}
             aria-label="List actions"
+            borderRadius="lg"
+            onClick={(e) => e.stopPropagation()}
           />
-          <MenuList bg="gray.800" borderColor="gray.700" minW="150px">
+          <MenuList
+            bg="gray.800"
+            borderColor="gray.700"
+            borderRadius="xl"
+            boxShadow="0 8px 32px rgba(0,0,0,0.4)"
+            minW="140px"
+            py={1}
+          >
             <MenuItem
-              icon={<Pencil size={14} />}
-              onClick={handleStartRename}
+              icon={<Pencil size={13} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleStartRename();
+              }}
               bg="gray.800"
-              _hover={{ bg: 'gray.700' }}
+              _hover={{ bg: 'whiteAlpha.100' }}
               fontSize="sm"
             >
               Rename
             </MenuItem>
             <MenuItem
-              icon={<Trash2 size={14} />}
-              onClick={handleDelete}
+              icon={<Trash2 size={13} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDelete();
+              }}
               bg="gray.800"
-              _hover={{ bg: 'gray.700' }}
+              _hover={{ bg: 'whiteAlpha.100' }}
               color="red.400"
               fontSize="sm"
             >
@@ -190,61 +217,63 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
         </Menu>
       </HStack>
 
-      {/* Word Cards */}
-      {list.words.length === 0 ? (
-        <Text color="gray.500" fontSize="sm" fontStyle="italic">
-          No words in this list yet. Browse the Vocabulary page to add words.
-        </Text>
-      ) : (
-        <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={3}>
-          {list.words.map((word) => (
-            <HStack
-              key={word._id}
-              bg="gray.900"
-              px={3}
-              py={2}
-              borderRadius="md"
-              borderWidth="1px"
-              borderColor="gray.700"
-              justify="space-between"
-            >
-              <VStack
-                align="start"
-                spacing={0}
-                flex={1}
-                minW={0}
-                cursor="pointer"
-                onClick={() => onViewDetails(word)}
-                _hover={{ opacity: 0.8 }}
-              >
-                <HStack spacing={2}>
-                  <Text color="brand.400" fontWeight="600" fontSize="sm" noOfLines={1}>
-                    {word.word}
-                  </Text>
-                  <Badge
-                    colorScheme={DIFFICULTY_COLORS[word.difficulty] || 'gray'}
-                    fontSize="2xs"
-                  >
-                    {word.difficulty}
-                  </Badge>
-                </HStack>
-                <Text color="gray.400" fontSize="xs" noOfLines={1}>
-                  {word.meaning}
-                </Text>
-              </VStack>
-              <IconButton
-                aria-label="Remove word"
-                icon={<X size={14} />}
-                size="xs"
-                variant="ghost"
-                color="gray.500"
-                _hover={{ color: 'red.400', bg: 'gray.700' }}
-                onClick={() => handleRemoveWord(word._id)}
-              />
+      {/* Collapsible Content */}
+      <Collapse in={isOpen} animateOpacity>
+        <Box pl={8} pr={1} pb={3} pt={1}>
+          {list.words.length === 0 ? (
+            <HStack spacing={2} color="gray.600" py={1}>
+              <BookOpen size={14} />
+              <Text fontSize="sm">Empty - save words from Vocabulary</Text>
             </HStack>
-          ))}
-        </SimpleGrid>
-      )}
+          ) : (
+            <Wrap spacing={2}>
+              {list.words.map((word) => (
+                <WrapItem key={word._id}>
+                  <HStack
+                    bg="gray.800"
+                    pl={3}
+                    pr={1.5}
+                    py={1.5}
+                    borderRadius="full"
+                    spacing={2}
+                    cursor="pointer"
+                    role="group"
+                    transition="all 0.15s"
+                    _hover={{ bg: 'gray.700' }}
+                    onClick={() => onViewDetails(word)}
+                  >
+                    <Box
+                      w="6px"
+                      h="6px"
+                      borderRadius="full"
+                      bg={DIFFICULTY_DOT_COLORS[word.difficulty] || 'gray.500'}
+                      flexShrink={0}
+                    />
+                    <Text fontSize="sm" color="gray.200" fontWeight="500">
+                      {word.word}
+                    </Text>
+                    <IconButton
+                      aria-label="Remove word"
+                      icon={<X size={11} />}
+                      size="xs"
+                      variant="ghost"
+                      color="gray.600"
+                      minW="20px"
+                      h="20px"
+                      opacity={0}
+                      _groupHover={{ opacity: 1 }}
+                      _hover={{ color: 'red.400', bg: 'whiteAlpha.200' }}
+                      borderRadius="full"
+                      transition="all 0.15s"
+                      onClick={(e) => handleRemoveWord(word._id, e)}
+                    />
+                  </HStack>
+                </WrapItem>
+              ))}
+            </Wrap>
+          )}
+        </Box>
+      </Collapse>
     </Box>
   );
 }

--- a/apps/user/src/features/word-list/components/list-card.tsx
+++ b/apps/user/src/features/word-list/components/list-card.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import {
+  Badge,
+  Box,
+  Heading,
+  HStack,
+  IconButton,
+  Input,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  SimpleGrid,
+  Text,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
+import { MoreVertical, Pencil, Trash2, X } from 'lucide-react';
+import { useRef, useState } from 'react';
+import type { Word } from '../../vocabulary/types';
+import type { WordList } from '../types';
+import { useDeleteList, useRemoveWord, useRenameList } from '../hooks/use-word-lists';
+
+interface ListCardProps {
+  list: WordList;
+  onViewDetails: (word: Word) => void;
+}
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+  beginner: 'green',
+  intermediate: 'blue',
+  advanced: 'purple',
+};
+
+export function ListCard({ list, onViewDetails }: ListCardProps) {
+  const renameList = useRenameList();
+  const deleteList = useDeleteList();
+  const removeWord = useRemoveWord();
+  const toast = useToast();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(list.name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleStartRename = () => {
+    setEditName(list.name);
+    setIsEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  const handleSaveRename = async () => {
+    const trimmedName = editName.trim();
+    if (!trimmedName || trimmedName === list.name) {
+      setIsEditing(false);
+      return;
+    }
+
+    try {
+      await renameList.mutateAsync({ listId: list._id, name: trimmedName });
+      setIsEditing(false);
+      toast({
+        title: 'List renamed',
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      });
+    } catch {
+      toast({
+        title: 'Failed to rename list',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleCancelRename = () => {
+    setEditName(list.name);
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSaveRename();
+    } else if (e.key === 'Escape') {
+      handleCancelRename();
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteList.mutateAsync(list._id);
+      toast({
+        title: `"${list.name}" deleted`,
+        status: 'info',
+        duration: 2000,
+        isClosable: true,
+      });
+    } catch {
+      toast({
+        title: 'Failed to delete list',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleRemoveWord = async (wordId: string) => {
+    try {
+      await removeWord.mutateAsync({ listId: list._id, wordId });
+    } catch {
+      toast({
+        title: 'Failed to remove word',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Box
+      bg="gray.800"
+      borderWidth="1px"
+      borderColor="gray.700"
+      borderRadius="lg"
+      p={5}
+    >
+      {/* List Header */}
+      <HStack justify="space-between" mb={4}>
+        {isEditing ? (
+          <HStack flex={1}>
+            <Input
+              ref={inputRef}
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onBlur={handleSaveRename}
+              size="sm"
+              bg="gray.900"
+              borderColor="gray.600"
+              _focus={{ borderColor: 'brand.400' }}
+              maxW="300px"
+            />
+          </HStack>
+        ) : (
+          <HStack spacing={3}>
+            <Heading size="md" color="white">
+              {list.name}
+            </Heading>
+            <Badge colorScheme="brand" variant="subtle" fontSize="xs">
+              {list.words.length} {list.words.length === 1 ? 'word' : 'words'}
+            </Badge>
+          </HStack>
+        )}
+
+        <Menu>
+          <MenuButton
+            as={IconButton}
+            icon={<MoreVertical size={16} />}
+            variant="ghost"
+            size="sm"
+            color="gray.400"
+            _hover={{ color: 'white', bg: 'gray.700' }}
+            aria-label="List actions"
+          />
+          <MenuList bg="gray.800" borderColor="gray.700" minW="150px">
+            <MenuItem
+              icon={<Pencil size={14} />}
+              onClick={handleStartRename}
+              bg="gray.800"
+              _hover={{ bg: 'gray.700' }}
+              fontSize="sm"
+            >
+              Rename
+            </MenuItem>
+            <MenuItem
+              icon={<Trash2 size={14} />}
+              onClick={handleDelete}
+              bg="gray.800"
+              _hover={{ bg: 'gray.700' }}
+              color="red.400"
+              fontSize="sm"
+            >
+              Delete
+            </MenuItem>
+          </MenuList>
+        </Menu>
+      </HStack>
+
+      {/* Word Cards */}
+      {list.words.length === 0 ? (
+        <Text color="gray.500" fontSize="sm" fontStyle="italic">
+          No words in this list yet. Browse the Vocabulary page to add words.
+        </Text>
+      ) : (
+        <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={3}>
+          {list.words.map((word) => (
+            <HStack
+              key={word._id}
+              bg="gray.900"
+              px={3}
+              py={2}
+              borderRadius="md"
+              borderWidth="1px"
+              borderColor="gray.700"
+              justify="space-between"
+            >
+              <VStack
+                align="start"
+                spacing={0}
+                flex={1}
+                minW={0}
+                cursor="pointer"
+                onClick={() => onViewDetails(word)}
+                _hover={{ opacity: 0.8 }}
+              >
+                <HStack spacing={2}>
+                  <Text color="brand.400" fontWeight="600" fontSize="sm" noOfLines={1}>
+                    {word.word}
+                  </Text>
+                  <Badge
+                    colorScheme={DIFFICULTY_COLORS[word.difficulty] || 'gray'}
+                    fontSize="2xs"
+                  >
+                    {word.difficulty}
+                  </Badge>
+                </HStack>
+                <Text color="gray.400" fontSize="xs" noOfLines={1}>
+                  {word.meaning}
+                </Text>
+              </VStack>
+              <IconButton
+                aria-label="Remove word"
+                icon={<X size={14} />}
+                size="xs"
+                variant="ghost"
+                color="gray.500"
+                _hover={{ color: 'red.400', bg: 'gray.700' }}
+                onClick={() => handleRemoveWord(word._id)}
+              />
+            </HStack>
+          ))}
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+}

--- a/apps/user/src/features/word-list/components/list-card.tsx
+++ b/apps/user/src/features/word-list/components/list-card.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
   Box,
+  Button,
   Collapse,
   Heading,
   HStack,
@@ -40,6 +47,8 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
   const removeWord = useRemoveWord();
   const toast = useToast();
   const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: true });
+  const { isOpen: isDeleteOpen, onOpen: onDeleteOpen, onClose: onDeleteClose } = useDisclosure();
+  const cancelRef = useRef<HTMLButtonElement>(null);
 
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(list.name);
@@ -93,6 +102,7 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
   const handleDelete = async () => {
     try {
       await deleteList.mutateAsync(list._id);
+      onDeleteClose();
       toast({
         title: `"${list.name}" deleted`,
         status: 'info',
@@ -124,7 +134,8 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
   };
 
   return (
-    <Box>
+    <>
+      <Box>
       {/* Section Header */}
       <HStack
         justify="space-between"
@@ -204,7 +215,7 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
               icon={<Trash2 size={13} />}
               onClick={(e) => {
                 e.stopPropagation();
-                handleDelete();
+                onDeleteOpen();
               }}
               bg="gray.800"
               _hover={{ bg: 'whiteAlpha.100' }}
@@ -262,6 +273,7 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
                       h="20px"
                       opacity={0}
                       _groupHover={{ opacity: 1 }}
+                      _focusVisible={{ opacity: 1 }}
                       _hover={{ color: 'red.400', bg: 'whiteAlpha.200' }}
                       borderRadius="full"
                       transition="all 0.15s"
@@ -275,5 +287,38 @@ export function ListCard({ list, onViewDetails }: ListCardProps) {
         </Box>
       </Collapse>
     </Box>
+
+      {/* Delete Confirmation */}
+      <AlertDialog
+        isOpen={isDeleteOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onDeleteClose}
+        isCentered
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent bg="gray.800" borderColor="gray.700" borderWidth="1px">
+            <AlertDialogHeader fontSize="lg" fontWeight="600" color="white">
+              Delete List
+            </AlertDialogHeader>
+            <AlertDialogBody color="gray.300">
+              Are you sure you want to delete &quot;{list.name}&quot;? This will remove all saved words from this list.
+            </AlertDialogBody>
+            <AlertDialogFooter gap={3}>
+              <Button ref={cancelRef} onClick={onDeleteClose} variant="ghost" size="sm">
+                Cancel
+              </Button>
+              <Button
+                colorScheme="red"
+                onClick={handleDelete}
+                size="sm"
+                isLoading={deleteList.isPending}
+              >
+                Delete
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </>
   );
 }

--- a/apps/user/src/features/word-list/components/save-to-list-button.tsx
+++ b/apps/user/src/features/word-list/components/save-to-list-button.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import {
+  Box,
+  HStack,
+  IconButton,
+  Input,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+  Text,
+  useDisclosure,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
+import { Bookmark, BookmarkCheck, Check, Plus } from 'lucide-react';
+import type { AxiosError } from 'axios';
+import { useState } from 'react';
+import { useAddWord, useCreateList, useWordLists } from '../hooks/use-word-lists';
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  // Axios error in dev mode
+  const axiosError = error as AxiosError<{ message?: string }>;
+  if (axiosError?.response?.data?.message) {
+    return axiosError.response.data.message;
+  }
+  // Production mode (interceptor wraps as Error)
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+}
+
+interface SaveToListButtonProps {
+  wordId: string;
+  isAuthenticated?: boolean;
+}
+
+export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToListButtonProps) {
+  const { data: lists = [] } = useWordLists();
+  const createList = useCreateList();
+  const addWord = useAddWord();
+  const toast = useToast();
+  const { onClose } = useDisclosure();
+
+  const [newListName, setNewListName] = useState('');
+
+  const isBookmarked = lists.some((list) =>
+    list.words.some((w) => w._id === wordId),
+  );
+
+  const listsContainingWord = new Set(
+    lists
+      .filter((list) => list.words.some((w) => w._id === wordId))
+      .map((list) => list._id),
+  );
+
+  const handleAddToList = async (listId: string, listName: string) => {
+    try {
+      await addWord.mutateAsync({ listId, wordId });
+      toast({
+        title: `Saved to "${listName}"`,
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      });
+    } catch (error: unknown) {
+      toast({
+        title: getErrorMessage(error, 'Failed to save word'),
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleCreateAndAdd = async () => {
+    const trimmedName = newListName.trim();
+    if (!trimmedName) return;
+
+    try {
+      const newList = await createList.mutateAsync(trimmedName);
+      await addWord.mutateAsync({ listId: newList._id, wordId });
+      setNewListName('');
+      onClose();
+      toast({
+        title: `Created "${trimmedName}" and saved word`,
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      });
+    } catch (error: unknown) {
+      toast({
+        title: getErrorMessage(error, 'Failed to create list'),
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleCreateAndAdd();
+    }
+  };
+
+  const isLoading = createList.isPending || addWord.isPending;
+
+  if (!isAuthenticated) {
+    return (
+      <IconButton
+        aria-label="Save to list"
+        icon={<Bookmark size={18} />}
+        size="sm"
+        colorScheme="brand"
+        variant="ghost"
+        _hover={{ bg: 'brand.600' }}
+        alignSelf="center"
+        onClick={() => {
+          toast({
+            title: 'Login required',
+            description: 'Please log in to save words to your lists.',
+            status: 'info',
+            duration: 3000,
+            isClosable: true,
+          });
+        }}
+      />
+    );
+  }
+
+  return (
+    <Popover placement="bottom-start" isLazy>
+      <PopoverTrigger>
+        <Box>
+          <IconButton
+            aria-label={isBookmarked ? 'Already saved' : 'Save to list'}
+            icon={
+              isBookmarked
+                ? <BookmarkCheck size={18} />
+                : <Bookmark size={18} />
+            }
+            size="sm"
+            colorScheme="brand"
+            variant="ghost"
+            _hover={{ bg: 'brand.600' }}
+            alignSelf="center"
+          />
+        </Box>
+      </PopoverTrigger>
+      <PopoverContent
+        bg="gray.800"
+        borderColor="gray.600"
+        maxW="250px"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <PopoverHeader borderColor="gray.700" fontSize="sm" fontWeight="600">
+          Save to list
+        </PopoverHeader>
+        <PopoverBody p={2}>
+          <VStack spacing={1} align="stretch" maxH="200px" overflowY="auto">
+            {lists.length === 0 && (
+              <Text fontSize="sm" color="gray.500" px={2} py={1}>
+                No lists yet. Create one below.
+              </Text>
+            )}
+            {lists.map((list) => {
+              const isInList = listsContainingWord.has(list._id);
+              return (
+                <HStack
+                  key={list._id}
+                  px={2}
+                  py={1.5}
+                  rounded="md"
+                  cursor={isInList ? 'default' : 'pointer'}
+                  _hover={{ bg: isInList ? 'transparent' : 'gray.700' }}
+                  opacity={isInList ? 0.6 : 1}
+                  onClick={() => {
+                    if (!isInList && !isLoading) {
+                      handleAddToList(list._id, list.name);
+                    }
+                  }}
+                  justify="space-between"
+                >
+                  <Text fontSize="sm" noOfLines={1}>
+                    {list.name}
+                  </Text>
+                  {isInList && <Check size={14} color="var(--chakra-colors-green-400)" />}
+                </HStack>
+              );
+            })}
+          </VStack>
+
+          <HStack mt={2} pt={2} borderTopWidth="1px" borderColor="gray.700">
+            <Input
+              size="sm"
+              placeholder="New list name..."
+              value={newListName}
+              onChange={(e) => setNewListName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              bg="gray.900"
+              borderColor="gray.600"
+              _focus={{ borderColor: 'brand.400' }}
+            />
+            <IconButton
+              aria-label="Create list"
+              icon={<Plus size={16} />}
+              size="sm"
+              colorScheme="brand"
+              isDisabled={!newListName.trim() || isLoading}
+              isLoading={isLoading}
+              onClick={handleCreateAndAdd}
+            />
+          </HStack>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/user/src/features/word-list/components/save-to-list-button.tsx
+++ b/apps/user/src/features/word-list/components/save-to-list-button.tsx
@@ -18,6 +18,7 @@ import { Bookmark, BookmarkCheck, Check, FolderPlus } from 'lucide-react';
 import type { AxiosError } from 'axios';
 import { useState } from 'react';
 import { useAddWord, useCreateList, useWordLists } from '../hooks/use-word-lists';
+import type { WordList } from '../types';
 
 function getErrorMessage(error: unknown, fallback: string): string {
   const axiosError = error as AxiosError<{ message?: string }>;
@@ -36,7 +37,7 @@ interface SaveToListButtonProps {
 }
 
 export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToListButtonProps) {
-  const { data: lists = [] } = useWordLists();
+  const { data: lists = [] } = useWordLists(isAuthenticated);
   const createList = useCreateList();
   const addWord = useAddWord();
   const toast = useToast();
@@ -79,8 +80,20 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
     const trimmedName = newListName.trim();
     if (!trimmedName) return;
 
+    let newList: WordList;
     try {
-      const newList = await createList.mutateAsync(trimmedName);
+      newList = await createList.mutateAsync(trimmedName);
+    } catch (error: unknown) {
+      toast({
+        title: getErrorMessage(error, 'Failed to create list'),
+        status: 'warning',
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    try {
       await addWord.mutateAsync({ listId: newList._id, wordId });
       setNewListName('');
       setShowCreateInput(false);
@@ -93,7 +106,7 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
       });
     } catch (error: unknown) {
       toast({
-        title: getErrorMessage(error, 'Failed to create list'),
+        title: getErrorMessage(error, `List created but failed to save word`),
         status: 'warning',
         duration: 3000,
         isClosable: true,

--- a/apps/user/src/features/word-list/components/save-to-list-button.tsx
+++ b/apps/user/src/features/word-list/components/save-to-list-button.tsx
@@ -105,6 +105,8 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
         isClosable: true,
       });
     } catch (error: unknown) {
+      setNewListName('');
+      setShowCreateInput(false);
       toast({
         title: getErrorMessage(error, `List created but failed to save word`),
         status: 'warning',
@@ -228,9 +230,19 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
                   px={4}
                   py={2.5}
                   cursor="pointer"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Save to ${list.name}`}
                   _hover={{ bg: 'whiteAlpha.100' }}
+                  _focusVisible={{ bg: 'whiteAlpha.100', outline: 'none' }}
                   onClick={() => {
                     if (!isLoading) {
+                      handleAddToList(list._id, list.name);
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if ((e.key === 'Enter' || e.key === ' ') && !isLoading) {
+                      e.preventDefault();
                       handleAddToList(list._id, list.name);
                     }
                   }}

--- a/apps/user/src/features/word-list/components/save-to-list-button.tsx
+++ b/apps/user/src/features/word-list/components/save-to-list-button.tsx
@@ -8,25 +8,22 @@ import {
   Popover,
   PopoverBody,
   PopoverContent,
-  PopoverHeader,
   PopoverTrigger,
   Text,
   useDisclosure,
   useToast,
   VStack,
 } from '@chakra-ui/react';
-import { Bookmark, BookmarkCheck, Check, Plus } from 'lucide-react';
+import { Bookmark, BookmarkCheck, Check, FolderPlus } from 'lucide-react';
 import type { AxiosError } from 'axios';
 import { useState } from 'react';
 import { useAddWord, useCreateList, useWordLists } from '../hooks/use-word-lists';
 
 function getErrorMessage(error: unknown, fallback: string): string {
-  // Axios error in dev mode
   const axiosError = error as AxiosError<{ message?: string }>;
   if (axiosError?.response?.data?.message) {
     return axiosError.response.data.message;
   }
-  // Production mode (interceptor wraps as Error)
   if (error instanceof Error) {
     return error.message;
   }
@@ -43,9 +40,10 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
   const createList = useCreateList();
   const addWord = useAddWord();
   const toast = useToast();
-  const { onClose } = useDisclosure();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const [newListName, setNewListName] = useState('');
+  const [showCreateInput, setShowCreateInput] = useState(false);
 
   const isBookmarked = lists.some((list) =>
     list.words.some((w) => w._id === wordId),
@@ -66,6 +64,7 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
         duration: 2000,
         isClosable: true,
       });
+      onClose();
     } catch (error: unknown) {
       toast({
         title: getErrorMessage(error, 'Failed to save word'),
@@ -84,6 +83,7 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
       const newList = await createList.mutateAsync(trimmedName);
       await addWord.mutateAsync({ listId: newList._id, wordId });
       setNewListName('');
+      setShowCreateInput(false);
       onClose();
       toast({
         title: `Created "${trimmedName}" and saved word`,
@@ -104,6 +104,10 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       handleCreateAndAdd();
+    }
+    if (e.key === 'Escape') {
+      setShowCreateInput(false);
+      setNewListName('');
     }
   };
 
@@ -133,7 +137,7 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
   }
 
   return (
-    <Popover placement="bottom-start" isLazy>
+    <Popover placement="bottom-start" isLazy isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
       <PopoverTrigger>
         <Box>
           <IconButton
@@ -154,67 +158,137 @@ export function SaveToListButton({ wordId, isAuthenticated = false }: SaveToList
       <PopoverContent
         bg="gray.800"
         borderColor="gray.600"
-        maxW="250px"
+        borderWidth="1px"
+        maxW="280px"
+        borderRadius="xl"
+        boxShadow="0 8px 32px rgba(0,0,0,0.4)"
         onClick={(e) => e.stopPropagation()}
+        _focus={{ outline: 'none' }}
       >
-        <PopoverHeader borderColor="gray.700" fontSize="sm" fontWeight="600">
-          Save to list
-        </PopoverHeader>
-        <PopoverBody p={2}>
-          <VStack spacing={1} align="stretch" maxH="200px" overflowY="auto">
-            {lists.length === 0 && (
-              <Text fontSize="sm" color="gray.500" px={2} py={1}>
-                No lists yet. Create one below.
+        <PopoverBody p={0}>
+          {/* Header */}
+          <HStack
+            px={4}
+            py={3}
+            borderBottomWidth="1px"
+            borderColor="gray.700"
+            justify="space-between"
+          >
+            <Text fontSize="sm" fontWeight="700" color="gray.200" letterSpacing="wide">
+              Save to list
+            </Text>
+            <Box
+              as="button"
+              onClick={() => setShowCreateInput(!showCreateInput)}
+              color="brand.400"
+              _hover={{ color: 'brand.300' }}
+              transition="color 0.15s"
+              cursor="pointer"
+              display="flex"
+              alignItems="center"
+              gap={1}
+            >
+              <FolderPlus size={15} />
+              <Text fontSize="xs" fontWeight="600">
+                New
               </Text>
+            </Box>
+          </HStack>
+
+          {/* List Items */}
+          <VStack spacing={0} align="stretch" maxH="220px" overflowY="auto" py={1}>
+            {lists.length === 0 && !showCreateInput && (
+              <Box px={4} py={6} textAlign="center">
+                <Text fontSize="sm" color="gray.500">
+                  No lists yet
+                </Text>
+                <Text fontSize="xs" color="gray.600" mt={1}>
+                  Tap &quot;New&quot; to create your first list
+                </Text>
+              </Box>
             )}
             {lists.map((list) => {
               const isInList = listsContainingWord.has(list._id);
               return (
                 <HStack
                   key={list._id}
-                  px={2}
-                  py={1.5}
-                  rounded="md"
-                  cursor={isInList ? 'default' : 'pointer'}
-                  _hover={{ bg: isInList ? 'transparent' : 'gray.700' }}
-                  opacity={isInList ? 0.6 : 1}
+                  px={4}
+                  py={2.5}
+                  cursor="pointer"
+                  _hover={{ bg: 'whiteAlpha.100' }}
                   onClick={() => {
-                    if (!isInList && !isLoading) {
+                    if (!isLoading) {
                       handleAddToList(list._id, list.name);
                     }
                   }}
                   justify="space-between"
+                  transition="background 0.15s"
                 >
-                  <Text fontSize="sm" noOfLines={1}>
-                    {list.name}
-                  </Text>
-                  {isInList && <Check size={14} color="var(--chakra-colors-green-400)" />}
+                  <HStack spacing={3} flex={1} minW={0}>
+                    <Box
+                      w="8px"
+                      h="8px"
+                      borderRadius="full"
+                      bg={isInList ? 'brand.400' : 'gray.600'}
+                      flexShrink={0}
+                      transition="background 0.2s"
+                    />
+                    <Text
+                      fontSize="sm"
+                      noOfLines={1}
+                      color={isInList ? 'white' : 'gray.300'}
+                      fontWeight={isInList ? '600' : '400'}
+                    >
+                      {list.name}
+                    </Text>
+                  </HStack>
+                  {isInList && (
+                    <Check
+                      size={15}
+                      color="var(--chakra-colors-brand-400)"
+                      strokeWidth={3}
+                    />
+                  )}
                 </HStack>
               );
             })}
           </VStack>
 
-          <HStack mt={2} pt={2} borderTopWidth="1px" borderColor="gray.700">
-            <Input
-              size="sm"
-              placeholder="New list name..."
-              value={newListName}
-              onChange={(e) => setNewListName(e.target.value)}
-              onKeyDown={handleKeyDown}
-              bg="gray.900"
-              borderColor="gray.600"
-              _focus={{ borderColor: 'brand.400' }}
-            />
-            <IconButton
-              aria-label="Create list"
-              icon={<Plus size={16} />}
-              size="sm"
-              colorScheme="brand"
-              isDisabled={!newListName.trim() || isLoading}
-              isLoading={isLoading}
-              onClick={handleCreateAndAdd}
-            />
-          </HStack>
+          {/* Create New List */}
+          {showCreateInput && (
+            <Box
+              px={3}
+              py={3}
+              borderTopWidth="1px"
+              borderColor="gray.700"
+            >
+              <HStack spacing={2}>
+                <Input
+                  size="sm"
+                  placeholder="List name"
+                  value={newListName}
+                  onChange={(e) => setNewListName(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  bg="gray.900"
+                  borderColor="gray.600"
+                  borderRadius="lg"
+                  _focus={{ borderColor: 'brand.400', boxShadow: '0 0 0 1px var(--chakra-colors-brand-400)' }}
+                  _placeholder={{ color: 'gray.500' }}
+                  autoFocus
+                />
+                <IconButton
+                  aria-label="Create list"
+                  icon={<FolderPlus size={16} />}
+                  size="sm"
+                  colorScheme="brand"
+                  borderRadius="lg"
+                  isDisabled={!newListName.trim() || isLoading}
+                  isLoading={isLoading}
+                  onClick={handleCreateAndAdd}
+                />
+              </HStack>
+            </Box>
+          )}
         </PopoverBody>
       </PopoverContent>
     </Popover>

--- a/apps/user/src/features/word-list/hooks/use-word-lists.ts
+++ b/apps/user/src/features/word-list/hooks/use-word-lists.ts
@@ -5,12 +5,13 @@ import { wordListApi } from '../services/word-list.api';
 
 const QUERY_KEY = ['word-lists'] as const;
 
-export function useWordLists() {
+export function useWordLists(enabled = true) {
   return useQuery({
     queryKey: QUERY_KEY,
     queryFn: wordListApi.getLists,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
+    enabled,
   });
 }
 

--- a/apps/user/src/features/word-list/hooks/use-word-lists.ts
+++ b/apps/user/src/features/word-list/hooks/use-word-lists.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { wordListApi } from '../services/word-list.api';
+
+const QUERY_KEY = ['word-lists'] as const;
+
+export function useWordLists() {
+  return useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: wordListApi.getLists,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+}
+
+export function useCreateList() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (name: string) => wordListApi.createList(name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+}
+
+export function useRenameList() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ listId, name }: { listId: string; name: string }) =>
+      wordListApi.renameList(listId, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+}
+
+export function useDeleteList() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (listId: string) => wordListApi.deleteList(listId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+}
+
+export function useAddWord() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ listId, wordId }: { listId: string; wordId: string }) =>
+      wordListApi.addWord(listId, wordId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+}
+
+export function useRemoveWord() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ listId, wordId }: { listId: string; wordId: string }) =>
+      wordListApi.removeWord(listId, wordId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+}

--- a/apps/user/src/features/word-list/index.tsx
+++ b/apps/user/src/features/word-list/index.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import {
+  Box,
+  Button,
+  Container,
+  Heading,
+  HStack,
+  Input,
+  Skeleton,
+  Text,
+  useDisclosure,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
+import { WordDetailsModal } from '@ielts/ui';
+import { BookOpen, Plus } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
+import { ListCard } from './components/list-card';
+import { SaveToListButton } from './components/save-to-list-button';
+import { useCreateList, useWordLists } from './hooks/use-word-lists';
+import type { Word } from '../vocabulary/types';
+
+export function WordListContainer() {
+  const { data: lists = [], isLoading } = useWordLists();
+  const createList = useCreateList();
+  const toast = useToast();
+  const [newListName, setNewListName] = useState('');
+  const [selectedWord, setSelectedWord] = useState<Word | null>(null);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const handleViewDetails = (word: Word) => {
+    setSelectedWord(word);
+    onOpen();
+  };
+
+  const handleCreateList = async () => {
+    const trimmedName = newListName.trim();
+    if (!trimmedName) return;
+
+    try {
+      await createList.mutateAsync(trimmedName);
+      setNewListName('');
+      toast({
+        title: `"${trimmedName}" created`,
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      });
+    } catch {
+      toast({
+        title: 'Failed to create list',
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleCreateList();
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Container maxW="6xl" py={8}>
+        <VStack spacing={6} align="stretch">
+          <Skeleton height="40px" width="200px" />
+          <Skeleton height="200px" borderRadius="lg" />
+          <Skeleton height="200px" borderRadius="lg" />
+        </VStack>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxW="6xl" py={8}>
+      <VStack spacing={6} align="stretch">
+        {/* Page Header */}
+        <HStack justify="space-between" flexWrap="wrap" gap={4}>
+          <Heading size="lg" color="white">
+            My Lists
+          </Heading>
+          <HStack>
+            <Input
+              size="sm"
+              placeholder="New list name..."
+              value={newListName}
+              onChange={(e) => setNewListName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              bg="gray.800"
+              borderColor="gray.600"
+              _focus={{ borderColor: 'brand.400' }}
+              maxW="220px"
+            />
+            <Button
+              size="sm"
+              colorScheme="brand"
+              leftIcon={<Plus size={16} />}
+              isDisabled={!newListName.trim() || createList.isPending}
+              isLoading={createList.isPending}
+              onClick={handleCreateList}
+            >
+              Create
+            </Button>
+          </HStack>
+        </HStack>
+
+        {/* Lists */}
+        {lists.length === 0 ? (
+          <Box textAlign="center" py={16}>
+            <VStack spacing={4}>
+              <Box color="gray.500">
+                <BookOpen size={48} />
+              </Box>
+              <Heading size="md" color="gray.400">
+                No lists yet
+              </Heading>
+              <Text color="gray.500" maxW="md">
+                Create your first vocabulary list above, then save words from the
+                Vocabulary page.
+              </Text>
+              <Button
+                as={Link}
+                href="/vocabulary"
+                colorScheme="brand"
+                variant="outline"
+                size="sm"
+              >
+                Browse Vocabulary
+              </Button>
+            </VStack>
+          </Box>
+        ) : (
+          <VStack spacing={4} align="stretch">
+            {lists.map((list) => (
+              <ListCard key={list._id} list={list} onViewDetails={handleViewDetails} />
+            ))}
+          </VStack>
+        )}
+      </VStack>
+
+      <WordDetailsModal
+        isOpen={isOpen}
+        onClose={onClose}
+        word={selectedWord}
+        headerAction={
+          <SaveToListButton
+            wordId={selectedWord?._id ?? ''}
+            isAuthenticated
+          />
+        }
+      />
+    </Container>
+  );
+}

--- a/apps/user/src/features/word-list/index.tsx
+++ b/apps/user/src/features/word-list/index.tsx
@@ -7,6 +7,7 @@ import {
   Heading,
   HStack,
   Input,
+  SimpleGrid,
   Skeleton,
   Text,
   useDisclosure,
@@ -14,7 +15,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { WordDetailsModal } from '@ielts/ui';
-import { BookOpen, Plus } from 'lucide-react';
+import { BookOpen, FolderPlus, Plus } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { ListCard } from './components/list-card';
@@ -27,8 +28,18 @@ export function WordListContainer() {
   const createList = useCreateList();
   const toast = useToast();
   const [newListName, setNewListName] = useState('');
+  const [showCreateInput, setShowCreateInput] = useState(false);
   const [selectedWord, setSelectedWord] = useState<Word | null>(null);
   const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const totalWords = lists.reduce((sum, list) => sum + list.words.length, 0);
+
+  const handleCreateBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setShowCreateInput(false);
+      setNewListName('');
+    }
+  };
 
   const handleViewDetails = (word: Word) => {
     setSelectedWord(word);
@@ -42,6 +53,7 @@ export function WordListContainer() {
     try {
       await createList.mutateAsync(trimmedName);
       setNewListName('');
+      setShowCreateInput(false);
       toast({
         title: `"${trimmedName}" created`,
         status: 'success',
@@ -62,86 +74,140 @@ export function WordListContainer() {
     if (e.key === 'Enter') {
       handleCreateList();
     }
+    if (e.key === 'Escape') {
+      setShowCreateInput(false);
+      setNewListName('');
+    }
   };
 
   if (isLoading) {
     return (
-      <Container maxW="6xl" py={8}>
-        <VStack spacing={6} align="stretch">
-          <Skeleton height="40px" width="200px" />
-          <Skeleton height="200px" borderRadius="lg" />
-          <Skeleton height="200px" borderRadius="lg" />
-        </VStack>
-      </Container>
+      <Box bg="gray.900" minH="80vh" py={10}>
+        <Container maxW="6xl">
+          <VStack spacing={6} align="stretch">
+            <HStack justify="space-between">
+              <Skeleton height="32px" width="160px" />
+              <Skeleton height="32px" width="100px" />
+            </HStack>
+            <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} height="200px" borderRadius="xl" />
+              ))}
+            </SimpleGrid>
+          </VStack>
+        </Container>
+      </Box>
     );
   }
 
   return (
-    <Container maxW="6xl" py={8}>
-      <VStack spacing={6} align="stretch">
-        {/* Page Header */}
-        <HStack justify="space-between" flexWrap="wrap" gap={4}>
-          <Heading size="lg" color="white">
-            My Lists
-          </Heading>
-          <HStack>
-            <Input
-              size="sm"
-              placeholder="New list name..."
-              value={newListName}
-              onChange={(e) => setNewListName(e.target.value)}
-              onKeyDown={handleKeyDown}
-              bg="gray.800"
-              borderColor="gray.600"
-              _focus={{ borderColor: 'brand.400' }}
-              maxW="220px"
-            />
-            <Button
-              size="sm"
-              colorScheme="brand"
-              leftIcon={<Plus size={16} />}
-              isDisabled={!newListName.trim() || createList.isPending}
-              isLoading={createList.isPending}
-              onClick={handleCreateList}
-            >
-              Create
-            </Button>
-          </HStack>
-        </HStack>
-
-        {/* Lists */}
-        {lists.length === 0 ? (
-          <Box textAlign="center" py={16}>
-            <VStack spacing={4}>
-              <Box color="gray.500">
-                <BookOpen size={48} />
-              </Box>
-              <Heading size="md" color="gray.400">
-                No lists yet
+    <Box bg="gray.900" minH="80vh" py={10}>
+      <Container maxW="6xl">
+        <VStack spacing={8} align="stretch">
+          {/* Header */}
+          <Box>
+            <HStack justify="space-between" mb={1}>
+              <Heading size="lg" color="white">
+                My Lists
               </Heading>
-              <Text color="gray.500" maxW="md">
-                Create your first vocabulary list above, then save words from the
-                Vocabulary page.
-              </Text>
-              <Button
-                as={Link}
-                href="/vocabulary"
-                colorScheme="brand"
-                variant="outline"
-                size="sm"
-              >
-                Browse Vocabulary
-              </Button>
-            </VStack>
+
+              {showCreateInput ? (
+                <HStack spacing={2} onBlur={handleCreateBlur}>
+                  <Input
+                    size="sm"
+                    placeholder="List name..."
+                    value={newListName}
+                    onChange={(e) => setNewListName(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    bg="gray.800"
+                    borderColor="gray.600"
+                    borderRadius="lg"
+                    _focus={{
+                      borderColor: 'brand.400',
+                      boxShadow: '0 0 0 1px var(--chakra-colors-brand-400)',
+                    }}
+                    maxW="180px"
+                    autoFocus
+                  />
+                  <Button
+                    size="sm"
+                    colorScheme="brand"
+                    borderRadius="lg"
+                    leftIcon={<Plus size={15} />}
+                    isDisabled={!newListName.trim() || createList.isPending}
+                    isLoading={createList.isPending}
+                    onClick={handleCreateList}
+                  >
+                    Create
+                  </Button>
+                </HStack>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  color="gray.400"
+                  leftIcon={<FolderPlus size={15} />}
+                  _hover={{ color: 'white', bg: 'whiteAlpha.100' }}
+                  onClick={() => setShowCreateInput(true)}
+                >
+                  New List
+                </Button>
+              )}
+            </HStack>
+            <Text fontSize="sm" color="gray.500">
+              {lists.length} {lists.length === 1 ? 'list' : 'lists'} · {totalWords}{' '}
+              {totalWords === 1 ? 'word' : 'words'}
+            </Text>
           </Box>
-        ) : (
-          <VStack spacing={4} align="stretch">
-            {lists.map((list) => (
-              <ListCard key={list._id} list={list} onViewDetails={handleViewDetails} />
-            ))}
-          </VStack>
-        )}
-      </VStack>
+
+          {/* Grid */}
+          {lists.length === 0 ? (
+            <VStack py={16} spacing={4}>
+              <Box color="gray.600">
+                <BookOpen size={36} />
+              </Box>
+              <VStack spacing={1}>
+                <Text color="gray.400" fontWeight="500">
+                  No lists yet
+                </Text>
+                <Text color="gray.600" fontSize="sm">
+                  Create a list and save words from Vocabulary.
+                </Text>
+              </VStack>
+              <HStack spacing={3} pt={2}>
+                <Button
+                  size="sm"
+                  colorScheme="brand"
+                  borderRadius="lg"
+                  onClick={() => setShowCreateInput(true)}
+                >
+                  Create List
+                </Button>
+                <Button
+                  as={Link}
+                  href="/vocabulary"
+                  size="sm"
+                  variant="ghost"
+                  color="gray.400"
+                  _hover={{ color: 'white' }}
+                >
+                  Browse Words
+                </Button>
+              </HStack>
+            </VStack>
+          ) : (
+            <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+              {lists.map((list) => (
+                <ListCard
+                  key={list._id}
+                  list={list}
+                  onViewDetails={handleViewDetails}
+                />
+              ))}
+            </SimpleGrid>
+          )}
+        </VStack>
+      </Container>
 
       <WordDetailsModal
         isOpen={isOpen}
@@ -154,6 +220,6 @@ export function WordListContainer() {
           />
         }
       />
-    </Container>
+    </Box>
   );
 }

--- a/apps/user/src/features/word-list/services/word-list.api.ts
+++ b/apps/user/src/features/word-list/services/word-list.api.ts
@@ -1,0 +1,38 @@
+import { axiosInstance } from '@ielts/auth';
+import type { WordList } from '../types';
+
+export const wordListApi = {
+  getLists: async (): Promise<WordList[]> => {
+    const { data } = await axiosInstance.get<{ data: WordList[] }>('/word-lists');
+    return data.data;
+  },
+
+  createList: async (name: string): Promise<WordList> => {
+    const { data } = await axiosInstance.post<{ data: WordList }>('/word-lists', { name });
+    return data.data;
+  },
+
+  renameList: async (listId: string, name: string): Promise<WordList> => {
+    const { data } = await axiosInstance.patch<{ data: WordList }>(
+      `/word-lists/${listId}`,
+      { name },
+    );
+    return data.data;
+  },
+
+  deleteList: async (listId: string): Promise<void> => {
+    await axiosInstance.delete(`/word-lists/${listId}`);
+  },
+
+  addWord: async (listId: string, wordId: string): Promise<WordList> => {
+    const { data } = await axiosInstance.post<{ data: WordList }>(
+      `/word-lists/${listId}/words`,
+      { wordId },
+    );
+    return data.data;
+  },
+
+  removeWord: async (listId: string, wordId: string): Promise<void> => {
+    await axiosInstance.delete(`/word-lists/${listId}/words/${wordId}`);
+  },
+};

--- a/apps/user/src/features/word-list/types.ts
+++ b/apps/user/src/features/word-list/types.ts
@@ -1,0 +1,9 @@
+import type { Word } from '../vocabulary/types';
+
+export interface WordList {
+  _id: string;
+  name: string;
+  words: Word[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/libs/ui/src/components/pronunciation-button.tsx
+++ b/libs/ui/src/components/pronunciation-button.tsx
@@ -3,7 +3,6 @@
 import {
   IconButton,
   Spinner,
-  Tooltip,
 } from '@chakra-ui/react';
 import { Volume2 } from 'lucide-react';
 import type { MouseEvent } from 'react';
@@ -30,12 +29,6 @@ export function PronunciationButton({
     return null;
   }
 
-  const tooltipLabel = isLoading
-    ? 'Loading voice...'
-    : isSpeaking
-    ? 'Playing...'
-    : 'Listen to pronunciation';
-
   const iconSize = size === 'md' ? 22 : 20;
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
@@ -45,24 +38,22 @@ export function PronunciationButton({
   };
 
   return (
-    <Tooltip label={tooltipLabel} placement="top">
-      <IconButton
-        aria-label="Pronounce word"
-        icon={
-          isLoading ? (
-            <Spinner size="sm" />
-          ) : (
-            <Volume2 size={iconSize} />
-          )
-        }
-        size={size}
-        colorScheme="brand"
-        variant={isSpeaking ? 'solid' : 'ghost'}
-        onClick={handleClick}
-        isDisabled={isLoading}
-        _hover={{ bg: 'brand.600' }}
-        alignSelf="center"
-      />
-    </Tooltip>
+    <IconButton
+      aria-label="Pronounce word"
+      icon={
+        isLoading ? (
+          <Spinner size="sm" />
+        ) : (
+          <Volume2 size={iconSize} />
+        )
+      }
+      size={size}
+      colorScheme="brand"
+      variant={isSpeaking ? 'solid' : 'ghost'}
+      onClick={handleClick}
+      isDisabled={isLoading}
+      _hover={{ bg: 'brand.600' }}
+      alignSelf="center"
+    />
   );
 }

--- a/libs/ui/src/lib/WordDetailsModal.tsx
+++ b/libs/ui/src/lib/WordDetailsModal.tsx
@@ -35,12 +35,14 @@ interface WordDetailsModalProps {
     topics?: Array<string | { _id: string; name: string }>;
     modules?: string[];
   } | null;
+  headerAction?: React.ReactNode;
 }
 
 export function WordDetailsModal({
   isOpen,
   onClose,
   word,
+  headerAction,
 }: WordDetailsModalProps) {
 
 
@@ -71,11 +73,12 @@ export function WordDetailsModal({
         >
           <VStack align="stretch" spacing={2}>
             <VStack align="start" spacing={2} w="full">
-              <HStack spacing={3} align="baseline" flexWrap="wrap">
+              <HStack spacing={3} align="center" flexWrap="wrap">
                 <Heading size="2xl" color="brand.400" lineHeight="shorter">
                   {word.word}
                 </Heading>
                 <PronunciationButton word={word.word} size="sm" />
+                {headerAction}
                 {word.partOfSpeech && (
                   <Badge
                     colorScheme="blue"


### PR DESCRIPTION
## Summary

Adds the ability for authenticated users to create, manage, and bookmark words into personal vocabulary lists. Includes a new backend module, frontend feature, and navigation integration.

## Changes

### Backend — New `word-list` Module

- **Model**: `WordList` schema with `user`, `name`, `words[]` — unique `{user, name}` compound index
- **Service**: CRUD operations with ownership-guarded queries, auto-move logic (one word per list), nested word population
- **Controller**: 6 endpoints following existing SRS controller pattern
- **Routes**: Protected routes with `authenticate` middleware + rate limiting
- **Sort**: Lists ordered by `createdAt` ascending (first-created first)

### Frontend — New `word-list` Feature

- **SaveToListButton**: Bookmark popover with list selection, inline "New" list creation, auto-close on save, and icon toggle (`Bookmark` ↔ `BookmarkCheck`)
- **ListCard**: Accordion-style collapsible sections with word pills (Wrap layout), difficulty dot indicators, rename/delete kebab menu, and hover-to-reveal remove button
- **WordListContainer**: My Lists page with collapsible create input (blur-to-dismiss), stats bar, empty state with CTAs
- **WordDetailsModal**: Added `headerAction` render prop for injecting the bookmark button
- **Navigation**: Added "My Lists" link to both desktop and mobile navs

### UX Details

- **One word per list**: Backend auto-moves word if saved to a different list (no duplicates across lists)
- **Unauthenticated users**: See bookmark icon but receive "Login required" toast
- **Popover auto-close**: Closes after successful save with success toast
- **Create input dismiss**: Blur-to-dismiss via `onBlur` + `relatedTarget` (no `useEffect`/`useRef`)
- **Header alignment**: Fixed vertical alignment of pronunciation + bookmark buttons (`center`)
- **Tooltip removal**: Removed auto-rendering tooltips from pronunciation and bookmark buttons

## Files Changed

### New Files
| File | Purpose |
|---|---|
| `apps/backend/src/modules/word-list/word-list.model.ts` | Mongoose schema |
| `apps/backend/src/modules/word-list/word-list.service.ts` | Business logic |
| `apps/backend/src/modules/word-list/word-list.controller.ts` | Route handlers |
| `apps/backend/src/modules/word-list/word-list.routes.ts` | Route definitions |
| `apps/user/src/features/word-list/types.ts` | TypeScript interfaces |
| `apps/user/src/features/word-list/services/word-list.api.ts` | API methods |
| `apps/user/src/features/word-list/hooks/use-word-lists.ts` | React Query hooks |
| `apps/user/src/features/word-list/components/save-to-list-button.tsx` | Bookmark popover |
| `apps/user/src/features/word-list/components/list-card.tsx` | Accordion list card |
| `apps/user/src/features/word-list/index.tsx` | Page container |
| `apps/user/src/app/my-lists/page.tsx` | Next.js route |

### Modified Files
| File | Change |
|---|---|
| `apps/backend/src/api.routes.ts` | Registered `/word-lists` route |
| `libs/ui/src/lib/WordDetailsModal.tsx` | Added `headerAction` prop, fixed alignment |
| `libs/ui/src/components/pronunciation-button.tsx` | Removed tooltip |
| `apps/user/src/features/vocabulary/index.tsx` | Injected `SaveToListButton` |
| `apps/user/src/components/navbar/desktop-nav.tsx` | Added "My Lists" link |
| `apps/user/src/components/navbar/mobile-nav.tsx` | Added "My Lists" link |

## Testing

- [x] CRUD operations (create, rename, delete lists)
- [x] Add/remove words from lists
- [x] Auto-move between lists (no duplicates)
- [x] Word details modal works from both Vocabulary and My Lists pages
- [x] Unauthenticated bookmark flow (toast feedback)
- [x] Popover auto-close after save
- [x] Create input blur-to-dismiss

Closes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full word lists system: create, rename, delete lists and manage words
  * "Save to List" button to add words to lists
  * New "My Lists" page for viewing and managing lists

* **Navigation**
  * "My Lists" added to desktop and mobile nav

* **Style**
  * Dashboard and landing feature cards switched from emojis to icon-based design
<!-- end of auto-generated comment: release notes by coderabbit.ai -->