### PR TITLE
feat(backend): add Vercel Cron daily inactivity emails with Brevo API bulk sending

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,3 +1,6 @@
-NEXT_PUBLIC_API_URL=http://localhost:3333/api/v1
+# API URL — Client-side (browser)
 # In production on Vercel, use: /api/v1 (proxied by Next.js rewrites)
+NEXT_PUBLIC_API_URL=http://localhost:3333/api/v1
+
+# App URLs
 NEXT_PUBLIC_USER_APP_URL=http://localhost:3000

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -11,17 +11,38 @@ JWT_SECRET=your-super-secret-jwt-key
 PORT=3333
 NODE_ENV=development
 
-# Email Configuration (for password reset)
-SMTP_HOST=smtp.gmail.com
+# Email Configuration — SMTP (Nodemailer)
+# Used for transactional emails: password reset, verification, email change
+SMTP_HOST=smtp-relay.brevo.com
 SMTP_PORT=587
-SMTP_USER=your-email@gmail.com
-SMTP_PASS=your-app-specific-password
-SMTP_FROM="App Name <no-reply@domain.com>"
+SMTP_USER=your-brevo-smtp-user@smtp-brevo.com
+SMTP_PASS=your-brevo-smtp-password
+SMTP_FROM='"App Name" <no-reply@domain.com>'
+
+# Email Configuration — Brevo REST API (NOTE: VERCEL-ONLY)
+# Used for bulk inactivity emails via Vercel Cron. Not needed on VPS with Agenda.
+BREVO_API_KEY=xkeysib-your-brevo-api-key
 
 # URLs
 CLIENT_URL=http://localhost:3000
 ADMIN_URL=http://localhost:3001
 
-# CORS (Optional - auto-derives from CLIENT_URL and ADMIN_URL if not set)
+# CORS (Optional — auto-derives from CLIENT_URL and ADMIN_URL if not set)
 # Only set this if you need additional origins beyond CLIENT_URL and ADMIN_URL
 # CORS_ORIGINS=http://localhost:3000,http://localhost:3001,https://preview.vercel.app
+
+# Cloudinary (image uploads)
+CLOUDINARY_CLOUD_NAME=your_cloud_name
+CLOUDINARY_API_KEY=your_api_key
+CLOUDINARY_API_SECRET=your_api_secret
+
+# Vercel Cron (NOTE: VERCEL-ONLY — not needed on VPS with Agenda)
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+CRON_SECRET=your-random-cron-secret
+
+# Agenda Job Scheduler (NOTE: VPS/Render only — keep false on Vercel)
+# Set to "true" when running on VPS/Render to enable Agenda-based scheduling
+ENABLE_AGENDA=false
+
+# Custom DNS (Optional — for resolving MongoDB SRV records on some ISPs/networks)
+# ENABLE_CUSTOM_DNS=true

--- a/apps/backend/src/api.routes.ts
+++ b/apps/backend/src/api.routes.ts
@@ -9,9 +9,11 @@ import topicsRoutes from './modules/topics/topics.routes';
 import userProfileRoutes from './modules/users/users-profile.routes';
 import wordsRoutes from './modules/words/words.routes';
 import wordListRoutes from './modules/word-list/word-list.routes';
+import cronRoutes from './modules/cron/cron.routes'; // NOTE: VERCEL-ONLY — Remove this import when migrating to VPS/Render
 
 const router = Router();
 
+router.use('/cron', cronRoutes); // NOTE: VERCEL-ONLY — Remove this route when migrating to VPS/Render
 router.use('/auth', authRoutes);
 router.use('/password', passwordResetRoutes);
 router.use('/users', userProfileRoutes);

--- a/apps/backend/src/config/agenda.ts
+++ b/apps/backend/src/config/agenda.ts
@@ -1,23 +1,55 @@
-import type { Agenda } from 'agenda';
 import mongoose from 'mongoose';
 
-export let agenda: Agenda;
+// Agenda instance — only initialized when ENABLE_AGENDA=true (VPS/Render mode).
+// On Vercel, this remains null and all schedule/cancel calls are safe no-ops.
+let agendaInstance: import('agenda').Agenda | null = null;
+
+export const getAgenda = () => agendaInstance;
+
+// Proxy that safely no-ops when Agenda is not initialized (Vercel mode).
+// This prevents crashes in controllers that import `agenda` at the top level.
+export const agenda = {
+  async schedule(...args: Parameters<import('agenda').Agenda['schedule']>) {
+    if (!agendaInstance) return;
+    return agendaInstance.schedule(...args);
+  },
+  async cancel(...args: Parameters<import('agenda').Agenda['cancel']>) {
+    if (!agendaInstance) return 0;
+    return agendaInstance.cancel(...args);
+  },
+  define(...args: Parameters<import('agenda').Agenda['define']>) {
+    if (!agendaInstance) return;
+    return agendaInstance.define(...args);
+  },
+  async start() {
+    if (!agendaInstance) return;
+    return agendaInstance.start();
+  },
+  async stop() {
+    if (!agendaInstance) return;
+    return agendaInstance.stop();
+  },
+};
+
+export const isAgendaEnabled = () => process.env.ENABLE_AGENDA === 'true';
 
 export const initAgenda = async () => {
-  // Use `new Function` to bypass the TypeScript compiler transforming `import()` to `require()`
-  // since tsconfig is set to CommonJS. This avoids the ERR_REQUIRE_ESM runtime crash.
+  if (!isAgendaEnabled()) {
+    console.log('⏭️  Agenda disabled (ENABLE_AGENDA !== "true"). Using Vercel Cron instead.');
+    return;
+  }
+
+  // Dynamic import to avoid ERR_REQUIRE_ESM when compiled to CommonJS
   const agendaImport = new Function('return import("agenda")')();
   const mongoBackendImport = new Function('return import("@agendajs/mongo-backend")')();
 
   const { Agenda: AgendaClass } = await agendaImport;
   const { MongoBackend: MongoBackendClass } = await mongoBackendImport;
 
-  agenda = new AgendaClass({
-    backend: new MongoBackendClass({ 
-      // Agenda v6 uses 'mongo' to accept an existing MongoDB connection instance.
-      // Reusing the mongoose connection is best practice and prevents DNS SRV errors.
-      mongo: mongoose.connection.db, 
-      collection: 'agendaJobs'
+  agendaInstance = new AgendaClass({
+    backend: new MongoBackendClass({
+      mongo: mongoose.connection.db,
+      collection: 'agendaJobs',
     }),
     processEvery: '1 minute',
   });
@@ -27,8 +59,8 @@ export const initAgenda = async () => {
 };
 
 async function graceful() {
-  if (agenda) {
-    await agenda.stop();
+  if (agendaInstance) {
+    await agendaInstance.stop();
   }
   process.exit(0);
 }

--- a/apps/backend/src/core/services/brevo-api.service.ts
+++ b/apps/backend/src/core/services/brevo-api.service.ts
@@ -1,0 +1,132 @@
+/**
+ * NOTE: VERCEL-ONLY — Safe to DELETE this entire file when migrating to VPS/Render.
+ *
+ * This service exists because Vercel Hobby has a 10-second function timeout,
+ * so we use Brevo's REST API (fast HTTP calls) instead of slow SMTP connections.
+ * On VPS with Agenda, there is no timeout — use EmailService.sendInactivityReminderEmail()
+ * via Nodemailer SMTP instead. See also: cron.controller.ts, cron.routes.ts
+ */
+import { Logger } from '../../utils';
+
+const BREVO_API_URL = 'https://api.brevo.com/v3/smtp/email';
+const BATCH_SIZE = 5;
+
+interface BrevoSender {
+  name: string;
+  email: string;
+}
+
+export interface BrevoEmailRequest {
+  to: { email: string; name: string };
+  subject: string;
+  htmlContent: string;
+}
+
+interface BrevoApiPayload {
+  sender: BrevoSender;
+  to: Array<{ email: string; name: string }>;
+  subject: string;
+  htmlContent: string;
+}
+
+export interface BulkSendResult {
+  totalSent: number;
+  totalFailed: number;
+  failures: Array<{ email: string; error: string }>;
+}
+
+export class BrevoApiService {
+  private static getApiKey(): string {
+    const apiKey = process.env.BREVO_API_KEY;
+    if (!apiKey) {
+      throw new Error('BREVO_API_KEY environment variable is not configured');
+    }
+    return apiKey;
+  }
+
+  private static getSender(): BrevoSender {
+    const smtpFrom =
+      process.env.SMTP_FROM || '"IELTS Vocabs" <noreply@ieltsvocabs.com>';
+    const match = smtpFrom.match(/"?([^"]*)"?\s*<(.+)>/);
+
+    return {
+      name: match?.[1]?.trim() || 'IELTS Vocabs',
+      email: match?.[2]?.trim() || 'noreply@ieltsvocabs.com',
+    };
+  }
+
+  private static async sendSingle(
+    request: BrevoEmailRequest
+  ): Promise<void> {
+    const sender = BrevoApiService.getSender();
+
+    const payload: BrevoApiPayload = {
+      sender,
+      to: [{ email: request.to.email, name: request.to.name }],
+      subject: request.subject,
+      htmlContent: request.htmlContent,
+    };
+
+    const response = await fetch(BREVO_API_URL, {
+      method: 'POST',
+      headers: {
+        'api-key': BrevoApiService.getApiKey(),
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Brevo API ${response.status}: ${errorBody}`);
+    }
+  }
+
+  /**
+   * Sends emails in parallel batches of BATCH_SIZE.
+   * Uses Promise.allSettled so one failure doesn't kill the entire batch.
+   */
+  static async sendBulk(
+    requests: BrevoEmailRequest[]
+  ): Promise<BulkSendResult> {
+    if (requests.length === 0) {
+      return { totalSent: 0, totalFailed: 0, failures: [] };
+    }
+
+    let totalSent = 0;
+    let totalFailed = 0;
+    const failures: Array<{ email: string; error: string }> = [];
+
+    for (let i = 0; i < requests.length; i += BATCH_SIZE) {
+      const batch = requests.slice(i, i + BATCH_SIZE);
+
+      const results = await Promise.allSettled(
+        batch.map((request) => BrevoApiService.sendSingle(request))
+      );
+
+      results.forEach((result, index) => {
+        const recipient = batch[index];
+        if (result.status === 'fulfilled') {
+          totalSent++;
+        } else {
+          totalFailed++;
+          const errorMessage =
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason);
+          failures.push({ email: recipient.to.email, error: errorMessage });
+          Logger.error(
+            `Failed to send email to ${recipient.to.email}: ${errorMessage}`
+          );
+        }
+      });
+    }
+
+    Logger.info(
+      `Bulk email complete: ${totalSent} sent, ${totalFailed} failed out of ${requests.length} total`
+    );
+
+    return { totalSent, totalFailed, failures };
+  }
+}

--- a/apps/backend/src/core/services/brevo-api.service.ts
+++ b/apps/backend/src/core/services/brevo-api.service.ts
@@ -10,6 +10,7 @@ import { Logger } from '../../utils';
 
 const BREVO_API_URL = 'https://api.brevo.com/v3/smtp/email';
 const BATCH_SIZE = 5;
+const BREVO_TIMEOUT_MS = 5_000;
 
 interface BrevoSender {
   name: string;
@@ -67,19 +68,32 @@ export class BrevoApiService {
       htmlContent: request.htmlContent,
     };
 
-    const response = await fetch(BREVO_API_URL, {
-      method: 'POST',
-      headers: {
-        'api-key': BrevoApiService.getApiKey(),
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify(payload),
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), BREVO_TIMEOUT_MS);
 
-    if (!response.ok) {
-      const errorBody = await response.text();
-      throw new Error(`Brevo API ${response.status}: ${errorBody}`);
+    try {
+      const response = await fetch(BREVO_API_URL, {
+        method: 'POST',
+        headers: {
+          'api-key': BrevoApiService.getApiKey(),
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`Brevo API ${response.status}: ${errorBody}`);
+      }
+    } catch (error) {
+      if ((error as Error).name === 'AbortError') {
+        throw new Error(`Brevo API timeout after ${BREVO_TIMEOUT_MS}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/apps/backend/src/core/services/email.service.ts
+++ b/apps/backend/src/core/services/email.service.ts
@@ -23,6 +23,9 @@ const transporter = nodemailer.createTransport({
   host: smtpHost || 'smtp.gmail.com',
   port,
   secure: port === 465,
+  pool: true,
+  maxConnections: 3,
+  maxMessages: 50,
   auth: {
     user: smtpUser,
     pass: smtpPass,

--- a/apps/backend/src/modules/cron/cron.controller.ts
+++ b/apps/backend/src/modules/cron/cron.controller.ts
@@ -151,7 +151,9 @@ export class CronController {
       const result = await BrevoApiService.sendBulk(emailRequests);
 
       return res.status(200).json({
-        success: true,
+        success: result.totalFailed === 0,
+        totalSent: result.totalSent,
+        totalFailed: result.totalFailed,
         message: `Daily inactivity sweep complete. ${result.totalSent} sent, ${result.totalFailed} failed.`,
       });
     } catch (error) {

--- a/apps/backend/src/modules/cron/cron.controller.ts
+++ b/apps/backend/src/modules/cron/cron.controller.ts
@@ -1,0 +1,165 @@
+/**
+ * NOTE: VERCEL-ONLY — Safe to DELETE this entire file when migrating to VPS/Render.
+ *
+ * This controller handles Vercel Cron's daily HTTP GET trigger for inactivity emails.
+ * On VPS, Agenda handles scheduling and triggers EmailService.sendInactivityReminderEmail()
+ * directly — no HTTP endpoint needed. See also: brevo-api.service.ts, cron.routes.ts
+ */
+import type { Request, Response } from 'express';
+import { User } from '../users/users.model';
+import {
+  BrevoApiService,
+  type BrevoEmailRequest,
+} from '../../core/services/brevo-api.service';
+
+const INACTIVITY_THRESHOLDS_DAYS = [3, 7, 10] as const;
+
+const verifyCronSecret = (req: Request): boolean => {
+  const authHeader = req.headers.authorization;
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret) return false;
+  return authHeader === `Bearer ${cronSecret}`;
+};
+
+const sanitizeHtml = (text: string): string =>
+  text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+interface InactivityEmailContent {
+  subject: string;
+  htmlContent: string;
+}
+
+const buildInactivityEmail = (
+  name: string,
+  daysInactive: number,
+  role: string
+): InactivityEmailContent => {
+  const baseUrl =
+    role === 'admin' ? process.env.ADMIN_URL : process.env.CLIENT_URL;
+  const appUrl = baseUrl ? new URL('/quiz', baseUrl).toString() : '#';
+  const safeName = sanitizeHtml(name);
+
+  let title = '';
+  let message = '';
+
+  if (daysInactive === 3) {
+    title = 'We miss you! 🚀';
+    message =
+      "It's been 3 days since your last quiz. Just 5 minutes of practice today will keep your vocabulary sharp!";
+  } else if (daysInactive === 7) {
+    title = "Don't lose your progress! 📉";
+    message =
+      "It's been a week! Consistency is key to mastering IELTS vocabulary. Log in now to jump back in.";
+  } else if (daysInactive === 10) {
+    title = 'Are you still there? 😢';
+    message =
+      '10 days have passed. Your vocabulary might be fading! Come back and continue your journey to IELTS success.';
+  } else {
+    title = 'Time to practice!';
+    message = `It's been ${daysInactive} days since your last practice.`;
+  }
+
+  return {
+    subject: `${title} - IELTS Vocabs`,
+    htmlContent: `
+      <h1>Hi ${safeName},</h1>
+      <p>${message}</p>
+      <a href="${appUrl}">Resume Practice Now</a>
+      <p>You can turn off smart learning reminders in your account settings.</p>
+    `,
+  };
+};
+
+export class CronController {
+  /**
+   * Daily sweep: find inactive users and send reminder emails in bulk.
+   * Triggered by Vercel Cron once per day.
+   *
+   * Uses Brevo REST API with parallel batching instead of
+   * sequential SMTP to handle hundreds of users within Vercel's timeout.
+   *
+   * Security: Only accessible with a valid CRON_SECRET Bearer token.
+   */
+  static async dailyInactivityEmails(req: Request, res: Response) {
+    if (!verifyCronSecret(req)) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const now = new Date();
+    const emailRequests: BrevoEmailRequest[] = [];
+
+    try {
+      for (const days of INACTIVITY_THRESHOLDS_DAYS) {
+        // Calculate the date range for "exactly N days ago" (24h window)
+        const targetDate = new Date(now);
+        targetDate.setDate(targetDate.getDate() - days);
+
+        const windowStart = new Date(targetDate);
+        windowStart.setHours(0, 0, 0, 0);
+
+        const windowEnd = new Date(targetDate);
+        windowEnd.setHours(23, 59, 59, 999);
+
+        // Find users whose last activity was exactly N days ago
+        const inactiveUsers = await User.find({
+          isEmailVerified: true,
+          status: 'active',
+          $or: [
+            // Last quiz OR last review — whichever is more recent
+            {
+              lastQuizDate: { $gte: windowStart, $lte: windowEnd },
+              $or: [
+                { lastReviewDate: { $exists: false } },
+                { lastReviewDate: { $lte: windowEnd } },
+              ],
+            },
+            {
+              lastReviewDate: { $gte: windowStart, $lte: windowEnd },
+              $or: [
+                { lastQuizDate: { $exists: false } },
+                { lastQuizDate: { $lte: windowEnd } },
+              ],
+            },
+          ],
+        })
+          .select('email name role lastQuizDate lastReviewDate')
+          .lean();
+
+        // Build email content for each inactive user and add to the bulk queue
+        for (const user of inactiveUsers) {
+          const { subject, htmlContent } = buildInactivityEmail(
+            user.name,
+            days,
+            user.role
+          );
+
+          emailRequests.push({
+            to: { email: user.email, name: user.name },
+            subject,
+            htmlContent,
+          });
+        }
+      }
+
+      // Send all collected emails in parallel batches via Brevo REST API
+      const result = await BrevoApiService.sendBulk(emailRequests);
+
+      return res.status(200).json({
+        success: true,
+        message: `Daily inactivity sweep complete. ${result.totalSent} sent, ${result.totalFailed} failed.`,
+      });
+    } catch (error) {
+      console.error('Cron daily-emails error:', error);
+      return res.status(500).json({
+        success: false,
+        message: 'Cron job failed',
+      });
+    }
+  }
+}

--- a/apps/backend/src/modules/cron/cron.routes.ts
+++ b/apps/backend/src/modules/cron/cron.routes.ts
@@ -1,0 +1,16 @@
+/**
+ * NOTE: VERCEL-ONLY — Safe to DELETE this entire file when migrating to VPS/Render.
+ *
+ * These routes expose the cron endpoint for Vercel's HTTP-based cron trigger.
+ * On VPS, Agenda runs inside the process — no HTTP routes needed for scheduling.
+ * Also remove the '/cron' route registration in api.routes.ts.
+ */
+import { Router } from 'express';
+import { CronController } from './cron.controller';
+
+const router = Router();
+
+// No auth middleware — secured by CRON_SECRET header instead
+router.get('/daily-emails', CronController.dailyInactivityEmails);
+
+export default router;

--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -11,5 +11,11 @@
       "src": "/(.*)",
       "dest": "/api/index.ts"
     }
+  ],
+  "crons": [
+    {
+      "path": "/api/v1/cron/daily-emails",
+      "schedule": "0 9 * * *"
+    }
   ]
 }

--- a/apps/user/.env.example
+++ b/apps/user/.env.example
@@ -1,8 +1,17 @@
-NEXT_PUBLIC_ADMIN_APP_URL=http://localhost:3001
-# Client-side API base. In production on Vercel, use: /api/v1 (proxied by Next.js rewrites)
-NEXT_PUBLIC_API_URL="http://localhost:3333/api/v1"
+# API URL — Client-side (browser)
+# In production on Vercel, use: /api/v1 (proxied by Next.js rewrites)
+NEXT_PUBLIC_API_URL=http://localhost:3333/api/v1
 
-# Server-side API base. Must always be an absolute URL.
-API_BASE_URL="http://localhost:3333/api/v1"
+# API URL — Server-side (must always be absolute)
+API_BASE_URL=http://localhost:3333/api/v1
 
+# App URLs
 NEXT_PUBLIC_USER_APP_URL=http://localhost:3000
+NEXT_PUBLIC_ADMIN_APP_URL=http://localhost:3001
+
+# Cloudinary (profile avatar uploads)
+NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=your_cloud_name
+NEXT_PUBLIC_CLOUDINARY_API_KEY=your_api_key
+
+# Google OAuth (Optional)
+# NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id


### PR DESCRIPTION
## Summary

Replaces the broken Agenda-based email scheduler with a Vercel Cron + Brevo REST API approach that works on Vercel's serverless platform.

## Problem

Agenda v6+ is ESM-only, causing `ERR_REQUIRE_ESM` on Vercel (CommonJS runtime). Serverless functions also can't maintain long-running background processes, so scheduled jobs never fire.

## Solution

### Vercel Cron (scheduling)
- Added `crons` config in `vercel.json` — triggers daily at 9 AM UTC
- Created `/api/v1/cron/daily-emails` endpoint secured by `CRON_SECRET` Bearer token
- Checks users inactive for 3, 7, and 10 days and sends reminder emails

### Brevo REST API (bulk sending)
- Created `BrevoApiService` that sends emails via Brevo's HTTP API instead of slow SMTP
- Uses **parallel batching** (5 emails at a time via `Promise.allSettled`) to fit within Vercel Hobby's 10-second function timeout
- One failed email does not block the rest of the batch

### Agenda proxy pattern (future VPS support)
- Rewrote `agenda.ts` with a proxy pattern gated by `ENABLE_AGENDA` env variable
- On Vercel: `ENABLE_AGENDA` is unset → Agenda never loads → no ESM error
- On VPS: Set `ENABLE_AGENDA=true` → Agenda initializes normally

## Files Changed

| File | Change |
|---|---|
| `src/config/agenda.ts` | Proxy pattern + `ENABLE_AGENDA` gate |
| `src/core/services/brevo-api.service.ts` | **New** — Brevo REST API with parallel batch sending |
| `src/core/services/email.service.ts` | Added Nodemailer connection pooling |
| `src/modules/cron/cron.controller.ts` | **New** — Vercel Cron handler for daily inactivity sweep |
| `src/modules/cron/cron.routes.ts` | **New** — Cron route registration |
| `src/api.routes.ts` | Registered `/cron` routes |
| `vercel.json` | Added `crons` schedule block |

## Required Environment Variables

| Variable | Description |
|---|---|
| `CRON_SECRET` | Random 32+ char string for securing the cron endpoint |
| `BREVO_API_KEY` | Brevo API key (from Dashboard → SMTP & API → API Keys) |

## VPS Migration

All Vercel-specific files are marked with `NOTE: VERCEL-ONLY` comments. Search the codebase for `VERCEL-ONLY` to find everything that should be removed when migrating to VPS/Render with Agenda.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily inactivity email notifications to remind users to return to the app
  * Integrated Brevo for improved email delivery and reliability

* **Chores**
  * Updated email service configuration variables
  * Added support for third-party integrations (Cloudinary, Google OAuth)
  * Optimized email service connection pooling for better performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->